### PR TITLE
add metaprogramming test+doc

### DIFF
--- a/elasticai/creator/metaprogramming.py
+++ b/elasticai/creator/metaprogramming.py
@@ -1,0 +1,46 @@
+import functools
+from typing import Callable, Any
+
+"""
+The meta programming functions in this module are mostly used to implement the decorator software design patterns 
+that allow users to add support for elastic ai functionalities, such as *precomputing* to custom `torch.nn.Module`s.
+"""
+
+
+def add_method(method_name: str, method: Callable) -> Callable[[type], type]:
+    """Python decorator for adding a method to a class definition.
+
+    Returns:
+        A class with a method called `method_name` added, that is implemented by `method`.
+
+    """
+
+    def wrapper(cls: type) -> type:
+        return cls
+
+    return wrapper
+
+
+def add_instance_attribute(
+    attribute_name: str, attribute: Any
+) -> Callable[[type], type]:
+    """Python decorator that adds an instance attribute to a class definition. This behaves as if the assignment was
+    `self.attribute_name = attribute` was issued after the call to the original `__init__` function of the class.
+    Returns:
+        A new class being identical to the original class definition, except for the `__init__` function that executes above assignment
+        as a last step
+
+    """
+
+    def adds(cls: type) -> type:
+        init: Any = cls.__init__
+
+        @functools.wraps(init)
+        def wrapped_init(self, *args, **kwargs):
+            init(self, *args, **kwargs)
+            setattr(self, attribute_name, attribute)
+
+        setattr(cls, "__init__", wrapped_init)
+        return cls
+
+    return adds

--- a/elasticai/creator/tests/test_metaprogramming.py
+++ b/elasticai/creator/tests/test_metaprogramming.py
@@ -1,0 +1,36 @@
+import unittest
+from abc import abstractmethod
+from typing import Protocol, runtime_checkable
+from unittest import TestCase
+
+from elasticai.creator.metaprogramming import add_method, add_instance_attribute
+
+
+class TestWrappingClasses(TestCase):
+    @unittest.SkipTest
+    def test_method(self):
+        def my_method(self) -> list[int]:
+            return [1]
+
+        @add_method(method_name="my_method", method=my_method)
+        class A:
+            ...
+
+        @runtime_checkable
+        class P(Protocol):
+            @abstractmethod
+            def my_method(self) -> list[int]:
+                ...
+
+        # below assignment should be correct for static type analysis
+        a: P = A()
+
+        self.assertTrue(isinstance(a, P))
+
+    def test_attribute(self):
+        @add_instance_attribute(attribute_name="my_attribute", attribute=4)
+        class A:
+            ...
+
+        self.assertTrue(not hasattr(A, "my_attribute"))
+        self.assertEqual(4, A().my_attribute)


### PR DESCRIPTION
adds metaprogramming functions to allow us extend existing pytorch modules easily to support our creator workflow