### PR TITLE
Remove jit support for binarizer

### DIFF
--- a/elasticai/creator/qat/functional.py
+++ b/elasticai/creator/qat/functional.py
@@ -7,7 +7,6 @@ import torch
 from torch import jit
 
 
-@jit.script
 def _heaviside(x):
     return torch.heaviside(x, torch.tensor([1.0]))
 

--- a/elasticai/creator/qat/functional.py
+++ b/elasticai/creator/qat/functional.py
@@ -8,7 +8,7 @@ from torch import jit
 
 
 def _heaviside(x):
-    return torch.heaviside(x, torch.tensor([1.0]))
+    return torch.heaviside(x, torch.tensor([1.0], device=x.device))
 
 
 # noinspection PyPep8Naming,PyAbstractClass


### PR DESCRIPTION
Torchscript Heaviside function not supported for gpu, hence for now removing the corresponding decorator