### PR TITLE
docs(readme): fix commands of install dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ By now we only support Sequential models for our translations.
 poetry can be installed in the following way:
 ```bash
 pip install poetry
-pip install pre-commit
-poetry install -D
+poetry install
+poetry shell
 pre-commit install
 npm install --save-dev @commitlint/{config-conventional,cli}
 sudo apt install ghdl


### PR DESCRIPTION
I updated the install dev dependencies in [README.md](https://github.com/es-ude/elastic-ai.creator/blob/0288e04e546dbc91d60884588fe5a31e0f81fa7f/README.md?plain=1#L51-L56), please check.