### PR TITLE
400 add math ops and refactored fixed point config

### DIFF
--- a/elasticai/creator/nn/quantized_grads/_math_operations.py
+++ b/elasticai/creator/nn/quantized_grads/_math_operations.py
@@ -1,0 +1,27 @@
+from abc import abstractmethod
+
+import torch
+from torch import Tensor
+
+from elasticai.creator.base_modules.conv1d import MathOperations as Conv1dOps
+from elasticai.creator.base_modules.linear import MathOperations as LinearOps
+from elasticai.creator.base_modules.lstm_cell import MathOperations as LSTMOps
+
+
+class MathOperations(LinearOps, LSTMOps, Conv1dOps):
+
+    @abstractmethod
+    def quantize(self, a: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    def add(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return self.quantize(a + b)
+
+    def matmul(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return self.quantize(torch.matmul(a, b))
+
+    def mul(self, a: Tensor, b: Tensor) -> Tensor:
+        return self.quantize(torch.mul(a, b))
+
+    def div(self, a: Tensor, b: Tensor) -> Tensor:
+        return self.quantize(torch.div(a, b))

--- a/elasticai/creator/nn/quantized_grads/fixed_point/__init__.py
+++ b/elasticai/creator/nn/quantized_grads/fixed_point/__init__.py
@@ -1,0 +1,8 @@
+from ._two_complement_fixed_point_config import FixedPointConfigV2
+from .math_operations import (
+    MathOperationsForwBackwHTE,
+    MathOperationsForwBackwStoch,
+    MathOperationsForwHTE,
+    MathOperationsForwStoch,
+)
+from .quantize_to_fixed_point import quantize_to_fxp_hte, quantize_to_fxp_stochastic

--- a/elasticai/creator/nn/quantized_grads/fixed_point/_round_to_fixed_point_autograd.py
+++ b/elasticai/creator/nn/quantized_grads/fixed_point/_round_to_fixed_point_autograd.py
@@ -1,0 +1,72 @@
+from typing import Any, Callable
+
+import torch
+
+from ._two_complement_fixed_point_config import FixedPointConfigV2
+from .quantize_to_fixed_point import quantize_to_fxp_hte, quantize_to_fxp_stochastic
+
+
+def _make_autograd_function_forw(
+    _quantize_to_fxp: Callable[[torch.Tensor, FixedPointConfigV2], torch.Tensor],
+) -> type[torch.autograd.Function]:
+    class QuantizeForw(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx: Any, *args: Any, **kwargs: Any) -> torch.Tensor:
+            if len(args) != 2:
+                raise TypeError(
+                    "apply() takes exactly two arguments "
+                    "(x: torch.Tensor, config: FixedPointConfig)"
+                )
+            if len(kwargs) != 0:
+                raise TypeError(
+                    f"apply() takes exactly two arguments "
+                    f"(x: torch.Tensor, config: FixedPointConfig)"
+                    f"You provided {len(kwargs)=} arguments. But should provide 0"
+                )
+            x: torch.Tensor = args[0]
+            forward_fxp_config: FixedPointConfigV2 = args[1]
+            return _quantize_to_fxp(x, forward_fxp_config)
+
+        @staticmethod
+        def backward(ctx: Any, *grad_outputs: Any) -> Any:
+            return *grad_outputs, None
+
+    return QuantizeForw
+
+
+def _make_autograd_function_forwbackw(
+    _quantize_to_fxp: Callable[[torch.Tensor, FixedPointConfigV2], torch.Tensor],
+) -> type[torch.autograd.Function]:
+    class QuantizeForwBackw(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx: Any, *args: Any, **kwargs: Any) -> torch.Tensor:
+            if len(args) != 3:
+                raise TypeError(
+                    "apply() takes exactly three arguments "
+                    "(x: torch.Tensor, config: FixedPointConfig)"
+                )
+            if len(kwargs) != 0:
+                raise TypeError(
+                    f"apply() takes exactly three arguments "
+                    f"(x: torch.Tensor, forward_config: FixedPointConfigV2, backward_config: FixedPointConfigV2)"
+                    f"You provided {len(kwargs)=} arguments. But should provide 0"
+                )
+            x: torch.Tensor = args[0]
+            forward_config: FixedPointConfigV2 = args[1]
+            ctx.back_config = args[2]
+            return _quantize_to_fxp(x, forward_config)
+
+        @staticmethod
+        def backward(ctx: Any, *grad_outputs: Any) -> Any:
+            return _quantize_to_fxp(*grad_outputs, ctx.back_config), None, None
+
+    return QuantizeForwBackw
+
+
+QuantizeForwStochastic = _make_autograd_function_forw(quantize_to_fxp_stochastic)
+QuantizeForwHTE = _make_autograd_function_forw(quantize_to_fxp_hte)
+
+QuantizeForwBackwStochastic = _make_autograd_function_forwbackw(
+    quantize_to_fxp_stochastic
+)
+QuantizeForwBackwHTE = _make_autograd_function_forwbackw(quantize_to_fxp_hte)

--- a/elasticai/creator/nn/quantized_grads/fixed_point/_two_complement_fixed_point_config.py
+++ b/elasticai/creator/nn/quantized_grads/fixed_point/_two_complement_fixed_point_config.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True)
+class FixedPointConfigV2:
+    total_bits: int
+    frac_bits: int
+
+    def __post_init__(self):
+        """
+        This python API call for dataclass is executed after init.
+        This way we check if the FixedPointConfigV2 is valid while keeping the config immutable.
+        """
+        if self.total_bits <= 0:
+            raise Exception(
+                f"total bits need to be > 0 for {self.__class__.__name__}. "
+                f"You have set {self.total_bits=}."
+            )
+        if self.frac_bits + 1 > self.total_bits:
+            raise Exception(
+                f"total bits-1 needs to be > frac bits for {self.__class__.__name__}."
+                f"You have set {self.total_bits=} and {self.frac_bits=}."
+            )
+
+    @property
+    def minimum_as_rational(self):
+        return -(2 ** (self.total_bits - self.frac_bits - 1))
+
+    @property
+    def maximum_as_rational(self):
+        return -self.minimum_as_rational - 1 / (2**self.frac_bits)
+
+    @property
+    def minimum_as_rational_tensor(self):
+        return torch.Tensor([self.minimum_as_rational])
+
+    @property
+    def maximum_as_rational_tensor(self):
+        return torch.Tensor([self.maximum_as_rational])

--- a/elasticai/creator/nn/quantized_grads/fixed_point/math_operations.py
+++ b/elasticai/creator/nn/quantized_grads/fixed_point/math_operations.py
@@ -1,0 +1,55 @@
+from typing import cast
+
+import torch
+
+from elasticai.creator.nn.quantized_grads._math_operations import MathOperations
+from elasticai.creator.nn.quantized_grads.fixed_point import FixedPointConfigV2
+from elasticai.creator.nn.quantized_grads.fixed_point._round_to_fixed_point_autograd import (
+    QuantizeForwBackwHTE,
+    QuantizeForwBackwStochastic,
+    QuantizeForwHTE,
+    QuantizeForwStochastic,
+)
+
+
+class MathOperationsForwStoch(MathOperations):
+    def __init__(self, forward: FixedPointConfigV2) -> None:
+        self.forward = forward
+
+    def quantize(self, a: torch.Tensor) -> torch.Tensor:
+        return cast(torch.Tensor, QuantizeForwStochastic.apply(a, self.forward))
+
+
+class MathOperationsForwHTE(MathOperations):
+    def __init__(self, forward: FixedPointConfigV2) -> None:
+        self.forward = forward
+
+    def quantize(self, a: torch.Tensor) -> torch.Tensor:
+        return cast(torch.Tensor, QuantizeForwHTE.apply(a, self.forward))
+
+
+class MathOperationsForwBackwStoch(MathOperations):
+    def __init__(
+        self, forward: FixedPointConfigV2, backward: FixedPointConfigV2
+    ) -> None:
+        self.forward = forward
+        self.backward = backward
+
+    def quantize(self, a: torch.Tensor) -> torch.Tensor:
+        return cast(
+            torch.Tensor,
+            QuantizeForwBackwStochastic.apply(a, self.forward, self.backward),
+        )
+
+
+class MathOperationsForwBackwHTE(MathOperations):
+    def __init__(
+        self, forward: FixedPointConfigV2, backward: FixedPointConfigV2
+    ) -> None:
+        self.forward = forward
+        self.backward = backward
+
+    def quantize(self, a: torch.Tensor) -> torch.Tensor:
+        return cast(
+            torch.Tensor, QuantizeForwBackwHTE.apply(a, self.forward, self.backward)
+        )

--- a/elasticai/creator/nn/quantized_grads/fixed_point/quantize_to_fixed_point.py
+++ b/elasticai/creator/nn/quantized_grads/fixed_point/quantize_to_fixed_point.py
@@ -1,0 +1,41 @@
+import torch
+
+from elasticai.creator.nn.quantized_grads.fixed_point import FixedPointConfigV2
+
+
+def quantize_to_fxp_stochastic(
+    number: torch.Tensor, fxp_conf: FixedPointConfigV2
+) -> torch.Tensor:
+    """
+    Round fixed point stochastic adds a noise of [-0.5/2**fracbits to 0.5/2**fracbits] on the input tensor.
+    The tensor is clamped and rounded to a fixed point number.
+    """
+    noise = (torch.rand_like(number) - 0.5) / (2**fxp_conf.frac_bits)
+    return _round_to_fixed_point_hte(
+        _clamp(number, fxp_conf) + noise, fxp_conf.frac_bits
+    )
+
+
+def quantize_to_fxp_hte(
+    number: torch.Tensor, fxp_conf: FixedPointConfigV2
+) -> torch.Tensor:
+    """
+    Round fixed point half to even.
+    The tensor is clamped and rounded to a fixed point number.
+    """
+    return _clamp(_round_to_fixed_point_hte(number, fxp_conf.frac_bits), fxp_conf)
+
+
+def _clamp(number: torch.Tensor, fxp_conf: FixedPointConfigV2) -> torch.Tensor:
+    return torch.clamp(
+        number,
+        fxp_conf.minimum_as_rational_tensor,
+        fxp_conf.maximum_as_rational_tensor,
+    )
+
+
+def _round_to_fixed_point_hte(number: torch.Tensor, frac_bits: int) -> torch.Tensor:
+    """
+    Implements round half to even with torch rounding function
+    """
+    return torch.round(number * (2**frac_bits)) / 2**frac_bits

--- a/elasticai/creator/nn/quantized_grads/fixed_point/test_quantize_to_fixed_point.py
+++ b/elasticai/creator/nn/quantized_grads/fixed_point/test_quantize_to_fixed_point.py
@@ -1,0 +1,100 @@
+import torch
+
+from elasticai.creator.nn.quantized_grads.fixed_point import FixedPointConfigV2
+from elasticai.creator.nn.quantized_grads.fixed_point.quantize_to_fixed_point import (
+    _clamp,
+    _round_to_fixed_point_hte,
+    quantize_to_fxp_hte,
+)
+
+
+def test_round_determinstic_to_fixed_point():
+    conf = FixedPointConfigV2(total_bits=8, frac_bits=2)
+    x = torch.range(-2, 2, step=0.1, dtype=torch.float32)
+
+    actual = _round_to_fixed_point_hte(x, conf.frac_bits)
+    expected = torch.Tensor(
+        [
+            -2.0,
+            -2.0,
+            -1.75,
+            -1.75,
+            -1.5,
+            -1.5,
+            -1.5,
+            -1.25,
+            -1.25,
+            -1.0,
+            -1.0,
+            -1.0,
+            -0.75,
+            -0.75,
+            -0.5,
+            -0.5,
+            -0.5,
+            -0.25,
+            -0.25,
+            -0.0,
+            0.0,
+            0.0,
+            0.25,
+            0.25,
+            0.5,
+            0.5,
+            0.5,
+            0.75,
+            0.75,
+            1.0,
+            1.0,
+            1.0,
+            1.25,
+            1.25,
+            1.5,
+            1.5,
+            1.5,
+            1.75,
+            1.75,
+            2.0,
+            2.0,
+        ]
+    )
+    assert torch.equal(actual, expected)
+
+
+def test_clamp_to_fixed_point():
+    conf = FixedPointConfigV2(total_bits=4, frac_bits=2)
+    x = torch.range(-3, 3, step=1, dtype=torch.float32)
+
+    actual = _clamp(x, conf)
+    expected = torch.Tensor([-2.0, -2.0, -1.0, 0.0, 1.0, 1.75, 1.75])
+    assert torch.equal(actual, expected)
+
+
+def test_quantize_determinstic_to_fixed_point():
+    conf = FixedPointConfigV2(total_bits=4, frac_bits=2)
+    x = torch.range(-3, 3, step=0.33, dtype=torch.float32)
+    actual = quantize_to_fxp_hte(x, conf)
+    expected = torch.Tensor(
+        [
+            -2.0,
+            -2.0,
+            -2.0,
+            -2.0,
+            -1.75,
+            -1.25,
+            -1.0,
+            -0.75,
+            -0.25,
+            -0.0,
+            0.25,
+            0.75,
+            1.0,
+            1.25,
+            1.5,
+            1.75,
+            1.75,
+            1.75,
+            1.75,
+        ]
+    )
+    assert torch.equal(actual, expected)

--- a/elasticai/creator/nn/quantized_grads/quantize.py
+++ b/elasticai/creator/nn/quantized_grads/quantize.py
@@ -1,0 +1,11 @@
+from typing import Protocol
+
+from elasticai.creator.nn.quantized_grads.quantization_config import QuantizationConfig
+
+
+class Quantize(Protocol):
+    config: QuantizationConfig
+
+    def quantize(self): ...
+
+    def clamp(self): ...

--- a/tests/system_tests/helper/test_parse_tensors_to_bytearray.py
+++ b/tests/system_tests/helper/test_parse_tensors_to_bytearray.py
@@ -35,6 +35,5 @@ def test_bytearray_to_tensor():
     fxp_conf = FixedPointConfig(total_bits=total_bits, frac_bits=frac_bits)
     dimensions = (2, 3, 4)
     expected = fxp_conf.as_rational(fxp_conf.as_integer(torch.randn(dimensions)))
-    print(f"{expected=}")
     result = parse_bytearray_to_fxp_tensor(input, total_bits, frac_bits, dimensions)
     assert torch.equal(result, expected)


### PR DESCRIPTION
This feature adds basic support for future use of quantized fixed point gradients. It includes a refactor of the existing a new  fixed point config which is refactored because the old one was doing to much. Following, I changed the naming a bit and have now a fixed point configuration with datafields only. The quantization function is now moved to the quantize_to_fixed_point file using the fixed point configuration. 