### PR TITLE
chore: add basic support for devenv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+source_url "https://raw.githubusercontent.com/cachix/devenv/82c0147677e510b247d8b9165c54f73d32dfd899/direnvrc" "sha256-7u4iDd1nZpxL4tCzmPG0dQgC5V+/44Ba+tHkPob1v2k="
+
+use devenv

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -1,4 +1,30 @@
 # Contribution Guide
+## Development Environment
+### devenv
+
+To share not only python packages for the development environment, but also
+other tools we offer a [devenv](https://devenv.sh) configuration.
+After installing the nix package manager and [nix](https://nix.dev/install-nix)
+and [installing devenv](https://devenv.sh/getting-started/#2-install-devenv) you
+can startup a development environment with
+```bash
+$ devenv shell
+```
+For more convenience we recommend combining this workflow with direnv for
+automatica shell activation as explained [here](https://devenv.sh/automatic-shell-activation/).
+
+Devenv will automatically give you access to all other relevant tools
+
+ * git
+ * uv
+ * ghdl for hw simulations (run via rosetta on apple silicon)
+ * gtkwave for visualizing waveforms produced by ghdl
+ * act for testing github workflows locally
+ * and more...
+
+for a full list of installed tools have a look at the `devenv.nix` file.
+
+
 ## Concepts
 The `elasticai.creator` aims to support
     1. the design and training of hardware optimization aware neural networks

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,168 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1734605856,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "f81cf7dc4cbfa46de11618af94e5983c5e600d8c",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733477122,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "7bd9e84d0452f6d2e63b6e6da29fe73fac951857",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-python": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733319315,
+        "owner": "cachix",
+        "repo": "nixpkgs-python",
+        "rev": "01263eeb28c09f143d59cd6b0b7c4cc8478efd48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "nixpkgs-python",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1734529975,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "72d11d40b9878a67c38f003c240c2d2e1811e72a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1734435836,
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4989a246d7a390a859852baddb1013f825435cee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1734425854,
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "0ddd26d0925f618c3a5d85a4fa5eb1e23a09491d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-python": "nixpkgs-python",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,65 @@
+{
+  pkgs,
+  lib,
+  config,
+  inputs,
+  ...
+}:
+
+let
+  unstablePkgs = import inputs.nixpkgs-unstable { system = pkgs.stdenv.system; };
+  pyp = pkgs.python311Packages;
+in
+{
+
+  packages = [
+    pkgs.git
+    pkgs.doxygen
+    pkgs.diffedit3
+    pkgs.asciidoctor
+    pkgs.gtkwave  # visualize wave forms from hw simulations
+    pkgs.python312
+    pkgs.python310
+    pkgs.hwatch  # continually rerun a command and print its output
+    pkgs.jujutsu  # next generation vcs for mental sanity
+    pkgs.diffedit3  # 3-pane merge editor
+    pkgs.act  # test github workflows locally
+    unstablePkgs.mypy  # python type checker
+    unstablePkgs.ruff  # linter/formatter for python
+    unstablePkgs.vale  # syntax aware linter for prose
+    unstablePkgs.act  # run github workflows locally
+  ]; 
+  languages.c.enable = true;
+  languages.python = {
+    enable = true;
+    package = pkgs.python311;
+    poetry.enable = true;
+    poetry.activate.enable = false;
+    uv.enable = false;
+    venv.enable = false;
+    
+    uv.package = unstablePkgs.uv;
+    uv.sync.enable = false;
+    uv.sync.allExtras = false;
+
+  };
+
+  ## Commented out while we're configuring pre-commit manually
+  # pre-commit.hooks = {
+  #   shellcheck.enable = true;
+  #   ripsecrets.enable = true; # don't commit secrets
+  #   ruff.enable = true; # lint and automatically fix simple problems/reformat
+  #   taplo.enable = true; # reformat toml
+  #   nixfmt-rfc-style.enable = true; # reformat nix
+  #   ruff-format.enable = true;
+  #   mypy = {
+  #     enable = false;
+  #   }; # check type annotations
+  #   end-of-file-fixer.enable = true;
+  #   commitizen.enable = true; # help adhering to commit style guidelines
+  #   check-toml.enable = true; # check toml syntax
+  #   check-case-conflicts.enable = true;
+  #   check-added-large-files.enable = true;
+  # };
+
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,12 @@
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+  nixpkgs-python:
+    url: github:cachix/nixpkgs-python
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
+  nixpkgs-unstable:
+    url: github:nixos/nixpkgs/nixpkgs-unstable
+imports:
+  - ./devenv_modules/ghdl/

--- a/devenv_modules/ghdl/devenv.nix
+++ b/devenv_modules/ghdl/devenv.nix
@@ -1,0 +1,15 @@
+{pkgs, inputs, ... }:
+
+let
+  unstablePkgs = import inputs.nixpkgs-unstable { system = pkgs.stdenv.system; };
+  rosettaPkgs =
+    if unstablePkgs.stdenv.isDarwin && unstablePkgs.stdenv.isAarch64 then 
+      unstablePkgs.pkgsx86_64Darwin
+    else 
+      unstablePkgs;
+in
+{
+  packages = [
+    rosettaPkgs.ghdl
+  ];
+}


### PR DESCRIPTION
This commit allows to automatically setup
a dev environment with all necessary dependencies
installed. It should work cross-platform on

* macos
* linux
* wsl

The current setup automatically installs
the rosetta version of ghdl on mac m1.

You can install `direnv` to automatically
load that environment on entering the shell.