### PR TITLE
feat: improve error handling when loading plugins

### DIFF
--- a/tests/unit/plugin_test.py
+++ b/tests/unit/plugin_test.py
@@ -1,0 +1,20 @@
+import pytest
+
+import elasticai.creator.plugin as p
+
+
+def test_importing_plugin_with_unkown_fields_raises_meaningful_error():
+    config_from_file = {
+        "name": "my_plugin",
+        "api_version": "0.1",
+        "version": "0.2",
+        "package": "mypackage",
+        "target_platform": "env5",
+        "target_runtime": "vhdl",
+        "new_unknown_field": "value",
+    }
+    with pytest.raises(
+        p.UnexpectedFieldError,
+        match="unexpected fields {'new_unknown_field'} for plugin 'Plugin'",
+    ):
+        p.build_plugin(config_from_file, p.Plugin)


### PR DESCRIPTION
Previously trying to instantiate a `Plugin` from
a dictionary just passed or failed with a hard
to parse error message from a call to inspect.Signature.bind 
Now we analyse expected and actual parameters
and raise more meaningful error when there is
an unexpected parameter in the loaded config.