### PR TITLE
refactor(utils): move ghdl_msg parsing to its own module

### DIFF
--- a/elasticai/creator/utils/ghdl_msg.py
+++ b/elasticai/creator/utils/ghdl_msg.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass
+class GhdlMsg:
+    type: Literal["assertion error", "simulation finished"]
+    file: str
+    line: int
+    column: int
+    time: str
+    msg: str
+
+    def render(self) -> str:
+        return (
+            "ghdl output:\n"
+            f"\ttype: {self.type}\n"
+            f"\tfile: {self.file}:{self.line}:{self.column}\n"
+            f"\ttime: {self.time}\n"
+            f"\tmsg: {self.msg}"
+        )
+
+
+def parse_ghdl_msg(txt: str) -> list[GhdlMsg]:
+    msgs = []
+    for line in txt.splitlines():
+        parts = line.split(":", maxsplit=5)
+        if len(parts) == 6:
+            msg = GhdlMsg(
+                type="assertion error",
+                msg=parts[5].strip(),
+                file=parts[0],
+                line=int(parts[1]),
+                column=int(parts[2]),
+                time=parts[3][1:],
+            )
+            msgs.append(msg)
+        elif line.startswith("simulation finished"):
+            msgs.append(
+                GhdlMsg(
+                    type="simulation finished",
+                    file=".",
+                    line=-1,
+                    column=-1,
+                    time=line.strip("simulation finished @"),
+                    msg="",
+                )
+            )
+        elif len(msgs) > 1:
+            msgs[-1].msg += line
+
+    return msgs

--- a/elasticai/creator/utils/hw_test_runner.py
+++ b/elasticai/creator/utils/hw_test_runner.py
@@ -14,6 +14,7 @@ from typing import Any, AsyncIterable, Callable, Coroutine, Iterator, Literal, T
 
 from ._console_out import Printer
 from ._run import run_and_process_pipes, run_and_wait
+from .ghdl_msg import GhdlMsg, parse_ghdl_msg
 
 CREATOR_PLUGIN_NAMESPACE = "elasticai.creator_plugins"
 
@@ -42,6 +43,35 @@ def ghdl_command(command: str, *args: str) -> tuple[str, ...]:
 
 def ghdl_import(*files: Path) -> None:
     run_and_wait(*ghdl_command("-i", *tuple(str(f.absolute()) for f in files)))
+
+
+@dataclass
+class _CondensedGhdlMsg:
+    type: Literal["assertion error", "simulation finished"]
+    file: str
+    line: int
+    column: int
+    times: list[str]
+    msg: str
+
+    def render(self) -> str:
+        return (
+            "ghdl output:\n"
+            f"\ttype: {self.type}\n"
+            f"\tfile: {self.file}:{self.line}:{self.column}\n"
+            f"\ttimes: {', '.join(self.times)}\n"
+            f"\tmsg: {self.msg}"
+        )
+
+    @classmethod
+    def from_msg(cls, m: GhdlMsg) -> "_CondensedGhdlMsg":
+        return cls(m.type, m.file, m.line, m.column, [m.time], m.msg)
+
+    def key(self) -> int:
+        return hash((self.type, self.file, self.line, self.column, self.msg))
+
+    def merge(self, other: "_CondensedGhdlMsg") -> None:
+        self.times.extend(other.times)
 
 
 class TestBenchReport:
@@ -150,85 +180,6 @@ class TestBench:
     def __repr__(self) -> str:
         file, name = self.file, self.name
         return f"TestBench({file=}, {name=})"
-
-
-@dataclass
-class GhdlMsg:
-    type: Literal["assertion error", "simulation finished"]
-    file: str
-    line: int
-    column: int
-    time: str
-    msg: str
-
-    def render(self) -> str:
-        return (
-            "ghdl output:\n"
-            f"\ttype: {self.type}\n"
-            f"\tfile: {self.file}:{self.line}:{self.column}\n"
-            f"\ttime: {self.time}\n"
-            f"\tmsg: {self.msg}"
-        )
-
-
-@dataclass
-class _CondensedGhdlMsg:
-    type: Literal["assertion error", "simulation finished"]
-    file: str
-    line: int
-    column: int
-    times: list[str]
-    msg: str
-
-    def render(self) -> str:
-        return (
-            "ghdl output:\n"
-            f"\ttype: {self.type}\n"
-            f"\tfile: {self.file}:{self.line}:{self.column}\n"
-            f"\ttimes: {', '.join(self.times)}\n"
-            f"\tmsg: {self.msg}"
-        )
-
-    @classmethod
-    def from_msg(cls, m: GhdlMsg) -> "_CondensedGhdlMsg":
-        return cls(m.type, m.file, m.line, m.column, [m.time], m.msg)
-
-    def key(self) -> int:
-        return hash((self.type, self.file, self.line, self.column, self.msg))
-
-    def merge(self, other: "_CondensedGhdlMsg") -> None:
-        self.times.extend(other.times)
-
-
-def parse_ghdl_msg(txt: str) -> list[GhdlMsg]:
-    msgs = []
-    for line in txt.splitlines():
-        parts = line.split(":", maxsplit=5)
-        if len(parts) == 6:
-            msg = GhdlMsg(
-                type="assertion error",
-                msg=parts[5].strip(),
-                file=parts[0],
-                line=int(parts[1]),
-                column=int(parts[2]),
-                time=parts[3][1:],
-            )
-            msgs.append(msg)
-        elif line.startswith("simulation finished"):
-            msgs.append(
-                GhdlMsg(
-                    type="simulation finished",
-                    file=".",
-                    line=-1,
-                    column=-1,
-                    time=line.strip("simulation finished @"),
-                    msg="",
-                )
-            )
-        elif len(msgs) > 1:
-            msgs[-1].msg += line
-
-    return msgs
 
 
 class VhdlTestBenchRunner:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ omit = [
   "elasticai/creator/*Tests/*py",
   "elasticai/creator/**/*_test.py",
   "elasticai/**/__init__.py",
+  "tests/*py",
+  "elasticai/creator/utils/_console_out.py",  # not testable
+  "elasticai/creator/utils/_run.py",  # not testable
 ]
 source = ["elasticai/creator"]
 command_line = "-m pytest -m 'not simulation'"

--- a/tests/unit/utils/hw_test_runner_test.py
+++ b/tests/unit/utils/hw_test_runner_test.py
@@ -1,6 +1,8 @@
 import re
-from elasticai.creator.utils.hw_test_runner import parse_ghdl_msg, GhdlMsg
+
 from pytest import fixture
+
+from elasticai.creator.utils.ghdl_msg import GhdlMsg, parse_ghdl_msg
 
 
 def test_re_matches_filename():
@@ -10,7 +12,7 @@ def test_re_matches_filename():
 
 class GhdlMsgParsingBase:
     @fixture
-    def parsed(self) -> str:
+    def parsed(self) -> list[GhdlMsg]:
         return parse_ghdl_msg(
             "elastic-ai.creator/elasticai/creator_plugins/padding/vhdl/padding_remover_tb.vhd:84:11:@380ps:(assertion error): expected single bit padded to 01000AAA but was 01000100\n"
             "some/other/path_tb.vhd:10:12:@24ps:(assertion error): expected a but was b"


### PR DESCRIPTION
The change should help separate easier to test
ghdl message parsing and building from the
actual test runner and renderer, that rely
heavily on the interaction with ghdl
and checking the output.
