### PR TITLE
feat(qgrads): add support for execution on specific devices

### DIFF
--- a/elasticai/creator/nn/quantized_grads/fixed_point/test_quantize_to_fixed_point.py
+++ b/elasticai/creator/nn/quantized_grads/fixed_point/test_quantize_to_fixed_point.py
@@ -14,7 +14,7 @@ def test_round_determinstic_to_fixed_point():
     conf = FixedPointConfigV2(total_bits=8, frac_bits=2)
     x = torch.arange(-2, 2.1, step=0.1, dtype=torch.float32)
 
-    actual = _round_to_fixed_point_hte(x, conf.frac_bits)
+    actual = _round_to_fixed_point_hte(x, conf.resolution_per_int)
     expected = torch.Tensor(
         [
             -2.0,
@@ -67,7 +67,7 @@ def test_round_determinstic_to_fixed_point_inplace():
     conf = FixedPointConfigV2(total_bits=8, frac_bits=2)
     x = torch.arange(-2, 2.1, step=0.1, dtype=torch.float32)
 
-    _round_to_fixed_point_hte_(x, conf.frac_bits)
+    _round_to_fixed_point_hte_(x, conf.resolution_per_int)
     actual = x
     expected = torch.Tensor(
         [

--- a/elasticai/creator/nn/quantized_grads/fixed_point/test_two_complement_fixed_point_config.py
+++ b/elasticai/creator/nn/quantized_grads/fixed_point/test_two_complement_fixed_point_config.py
@@ -1,0 +1,11 @@
+import dataclasses
+
+import pytest
+
+from .two_complement_fixed_point_config import FixedPointConfigV2
+
+
+def test_two_complement_fixed_point_config_is_frozen():
+    config = FixedPointConfigV2(total_bits=8, frac_bits=2)
+    with pytest.raises(dataclasses.FrozenInstanceError):  #
+        config.total_bits = 4

--- a/elasticai/creator/nn/quantized_grads/fixed_point/two_complement_fixed_point_config.py
+++ b/elasticai/creator/nn/quantized_grads/fixed_point/two_complement_fixed_point_config.py
@@ -1,12 +1,20 @@
+import dataclasses
 from dataclasses import dataclass
 
 import torch
 
 
-@dataclass(frozen=True)
+@dataclass
 class FixedPointConfigV2:
+    """
+    This class behaves almost like a frozen instance,
+    but calculates and sets minimum_as_rational_tensor and maximum_as_rational_tensor just once in __post__init__.
+    After the __post_init__ the __setattr__ and __getattr__ methods block the change of variables.
+    """
+
     total_bits: int
     frac_bits: int
+    device: torch.device = torch.get_default_device()
 
     def __post_init__(self):
         """
@@ -23,19 +31,24 @@ class FixedPointConfigV2:
                 f"total bits-1 needs to be > frac bits for {self.__class__.__name__}."
                 f"You have set {self.total_bits=} and {self.frac_bits=}."
             )
+        self.minimum_as_rational_tensor = torch.Tensor(
+            [-(2 ** (self.total_bits - self.frac_bits - 1))]
+        ).to(device=self.device)
+        self.maximum_as_rational_tensor = torch.Tensor(
+            [-self.minimum_as_rational_tensor - 1 / (2**self.frac_bits)]
+        ).to(device=self.device)
+        self.resolution_per_int = torch.Tensor([2**self.frac_bits]).to(
+            device=self.device
+        )
 
-    @property
-    def minimum_as_rational(self):
-        return -(2 ** (self.total_bits - self.frac_bits - 1))
+    def __setattr__(self, name, value):
+        if hasattr(self, "resolution_per_int"):
+            raise dataclasses.FrozenInstanceError(self.__class__.__name__, name)
+        else:
+            super().__setattr__(name, value)
 
-    @property
-    def maximum_as_rational(self):
-        return -self.minimum_as_rational - 1 / (2**self.frac_bits)
-
-    @property
-    def minimum_as_rational_tensor(self):
-        return torch.Tensor([self.minimum_as_rational])
-
-    @property
-    def maximum_as_rational_tensor(self):
-        return torch.Tensor([self.maximum_as_rational])
+    def __delattr__(self, name):
+        if hasattr(self, "resolution_per_int"):
+            raise dataclasses.FrozenInstanceError(self.__class__.__name__, name)
+        else:
+            super().__delattr__(name)


### PR DESCRIPTION
# Problem 
Since the device of each tensor needs to be the same to perform operations, we need to make sure, that the fixedpointconfigs values can be set on the device. Thus, the device needs to be to the fixed point configuration.

However, when using 

```python 
@property
def minimum_as_rational_tensor(self):
        return torch.Tensor([self.minimum_as_rational]).to(self.device)
```
two problems occure. 
1. The tensor is transferred to the device every time the value is called.
2. The value self.minimum_as_rational is called every time which includes multiple computations.

Ideally, every value is computed just once and then is referred to. Unfortunatly, python dataclasses can not compute something once. Also, computing something during post_init is not possible, because the dataclass is frozen and does not allow changes. 


# Proposal
So what I need is the following behaviour for init/post_init.
1. Pass arguments to normal dataclass.
2. Compute the tensors in the post_init.
3. Emulate behaviour of frozen dataclasses. 

Therefore, I came up with a cheesy solution, which solves the problem. 
The [python documentation for dataclasses](https://docs.python.org/3/library/dataclasses.html#frozen-instances) states that they just remove `__setattr__` and `__delattr__`. Unfortunately, I can not inherit the `dataclass(frozen=True).__setattr__` and `dataclass(frozen=True).__delattr__`.  However, I can check if the last value I want to pre-compute, before freezing the dataclass is set. Therefore, I check if the attribute exists.

Since this is now possible, I added also a field for the resolution per integer to the dataclass, since this is computed multiple times during the round to fixed point functions. 

For the stochastic rounding, the noise needs also to be on the same device, so we take the fxp_conf device. 