### PR TITLE
chore(devenv): support vivado and add options to ghdl module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,12 +246,10 @@ Temporary Items
 
 # Ignore .pyc files
 *.pyc
-/elasticai/creator/nn/fixed_point/linear/fp_linear.tpl copy.vhd
-/presentation/presentation.html
-/presentation/presentation.pdf
 /vhdl93-bnf.html
-.devenv/
+.devenv*
 .direnv/
+devenv.local.nix
 build/
 justfile
 .zed/

--- a/devenv.nix
+++ b/devenv.nix
@@ -29,12 +29,16 @@ let
  
 {
 
+  # override these in your devenv.local.nix as needed
+  languages.vhdl = {
+    enable = lib.mkDefault true;  
+    vivado.enable = lib.mkDefault false;
+  };
+
   packages = [
     pkgs.kramdown-asciidoc
     pkgs.gtkwave  # visualize wave forms from hw simulations
     antoraWithKroki
-    pkgs.antora  # documentation generator
-    pkgs.xunit-viewer
     unstablePkgs.mypy  # python type checker
     unstablePkgs.ruff  # linter/formatter for python
     unstablePkgs.vale  # syntax aware linter for prose
@@ -149,6 +153,7 @@ let
 
     "build:all" = {};
     "clean:all" = {};
+
   };
 
   ## Commented out while we're configuring pre-commit manually

--- a/devenv_modules/ghdl/Readme.adoc
+++ b/devenv_modules/ghdl/Readme.adoc
@@ -1,0 +1,31 @@
+= Vhdl devenv module
+
+The module provides ghdl (using rosetta on apple silicon) and vivado.
+As long as devenv does not support composition of devenv.yaml files
+you have to ensure that your devenv.yaml contains
+
+[source, nix]
+----
+inputs:
+  vivado:
+    url: github:lschuermann/nur-packages
+	inputs:
+	  nixpkgs:
+	    follows: nixpkgs
+----
+This will make the nix build rules for vivado available.
+
+You have to download the vivado installer yourself from
+ https://www.xilinx.com/member/forms/download/xef.html?filename=Xilinx_Unified_2020.1_0602_1208.tar.gz
+and add it to your nix store.
+Since this is a large file (35GiB) you probably need to use this method https://nixos.wiki/wiki/Cheatsheet#Adding_files_to_the_store
+and add it to your nix store.
+
+.Available Options
+[source, nix]
+----
+ languages.vhdl = {
+  enable = false;
+  vivado.enable = false;
+};
+----

--- a/devenv_modules/ghdl/devenv.nix
+++ b/devenv_modules/ghdl/devenv.nix
@@ -1,4 +1,17 @@
-{pkgs, inputs, ... }:
+# As long as devenv does not support
+# composition of devenv.yaml files you have to
+# ensure that your devenv.yaml includes the following
+# definition:
+#
+# vivado:
+#   url: github:lschuermann/nur-packages
+#   inputs:
+#     nixpkgs:
+#       follows: nixpkg
+#
+#
+
+{pkgs, inputs, lib, config, ... }:
 
 let
   unstablePkgs = import inputs.nixpkgs-unstable { system = pkgs.stdenv.system; };
@@ -9,7 +22,27 @@ let
       unstablePkgs;
 in
 {
-  packages = [
-    rosettaPkgs.ghdl
-  ];
+  options = {
+    languages.vhdl = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "set to true to include ghdl";
+      };
+      vivado.enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Install vivado. Important: you have to download the vivado installer yourself and place it in the nix store.";
+      };
+    };
+  };
+
+  config.packages = let
+    vivadoPkgs = import inputs.vivado {pkgs = pkgs;};
+  in
+    [
+      (lib.mkIf config.languages.vhdl.enable rosettaPkgs.ghdl )
+      (lib.mkIf config.languages.vhdl.vivado.enable vivadoPkgs.vivado-2020_1)
+    ];
+  
 }

--- a/docs/modules/ROOT/examples/devenv.local.with-cuda.nix
+++ b/docs/modules/ROOT/examples/devenv.local.with-cuda.nix
@@ -1,0 +1,31 @@
+{pkgs, lib, ...} :
+
+let
+  buildInputs = with pkgs; [
+    cudaPackages.cuda_cudart
+    cudaPackages.cudatoolkit
+    cudaPackages.cudnn
+    stdenv.cc.cc
+    libuv
+    zlib
+  ];
+in 
+{
+  env.UV_PYTHON_PREFERENCE = lib.mkForce "only-system";
+  packages = with pkgs; [
+    cudaPackages.cuda_nvcc
+  ];
+
+  languages.vhdl.enable = true;
+  languages.vhdl.vivado.enable = true;
+
+  env = {
+    LD_LIBRARY_PATH = "${
+      with pkgs;
+      lib.makeLibraryPath buildInputs
+    }:/run/opengl-driver/lib:/run/opengl-driver-32/lib";
+    XLA_FLAGS = "--xla_gpu_cuda_data_dir=${pkgs.cudaPackages.cudatoolkit}"; # For tensorflow with GPU support
+    CUDA_PATH = pkgs.cudaPackages.cudatoolkit;
+  };
+
+}


### PR DESCRIPTION
The ghdl devenv submodule can now provide vivado.
This is mostly useful on nixos systems, where
it represents basically the only way to make
vivado available. Therefore it is disabled
by default.

Additionally the inclusion of ghdl can be turned
of now in your devenv.local.nix by setting

  languages.vhdl.enable = false;