### PR TITLE
feat(ir): turn ir.Graph into a IrData object

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,7 +140,7 @@ myst_heading_slug = True
 
 
 html_theme_options = {
-    "source_repository": "https://github.com/es-ude/elasticai.creator/",
+    "source_repository": "https://github.com/es-ude/elastic-ai.creator/",
     "source_branch": "main",
     "source_directory": "docs",
 }

--- a/elasticai/creator/ir/graph.py
+++ b/elasticai/creator/ir/graph.py
@@ -1,27 +1,55 @@
 from collections.abc import Callable, Iterable, Iterator, Mapping
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from .core import Edge, Node
 from .graph_delegate import GraphDelegate
-from .graph_iterators import bfs_iter_down, bfs_iter_up, dfs_pre_order
+from .graph_iterators import (
+    bfs_iter_down,
+    bfs_iter_up,
+    dfs_pre_order,
+)
+from .ir_data import IrData
 
 N = TypeVar("N", bound=Node)
 E = TypeVar("E", bound=Edge)
 
 
-class Graph(Generic[N, E]):
+class Graph(IrData, Generic[N, E], create_init=False):
+    __slots__ = ("data", "_g", "_node_data", "_edge_data", "_node_fn", "_edge_fn")
+
     def __init__(
-        self, nodes: Iterable[N] = tuple(), edges: Iterable[E] = tuple()
+        self,
+        *,
+        node_fn: Callable[[dict], N] = Node,
+        edge_fn: Callable[[dict], E] = Edge,
+        nodes: Iterable[N] = tuple(),
+        edges: Iterable[E] = tuple(),
+        data=None,
     ) -> None:
+        if data is None:
+            data = {}
+        if "nodes" not in data:
+            data["nodes"] = {}
+        if "edges" not in data:
+            data["edges"] = {}
+        super().__init__(data)
         self._g: GraphDelegate[str] = GraphDelegate()
-        self._edge_data: dict[tuple[str, str], E] = dict()
-        self._node_data: dict[str, N] = dict()
-        self.add_edges(edges)
-        self.add_nodes(nodes)
+        self._node_data = data["nodes"]
+        self._edge_data = data["edges"]
+        for n in self._node_data:
+            self._g.add_node(n)
+        for src, sink in self._edge_data:
+            self._g.add_edge(src, sink)
+        for n in nodes:
+            self.add_node(n)
+        for e in edges:
+            self.add_edge(e)
+        self._node_fn = node_fn
+        self._edge_fn = edge_fn
 
     def add_node(self, n: N) -> None:
         self._g.add_node(n.name)
-        self._node_data[n.name] = n
+        self._node_data[n.name] = n.data
 
     def add_nodes(self, ns: Iterable[N]) -> None:
         for n in ns:
@@ -33,7 +61,7 @@ class Graph(Generic[N, E]):
 
     def add_edge(self, e: E) -> None:
         self._g.add_edge(e.src, e.sink)
-        self._edge_data[(e.src, e.sink)] = e
+        self._edge_data[(e.src, e.sink)] = e.data
 
     def successors(self, node: str | N) -> Mapping[str, N]:
         if not isinstance(node, str):
@@ -42,7 +70,7 @@ class Graph(Generic[N, E]):
         def _successors():
             return self._g.get_successors(node)
 
-        return _ReadOnlyMappingInOrderAsIterable(_successors, self._node_data)
+        return self._get_node_mapping(_successors)
 
     def predecessors(self, node: str | N) -> Mapping[str, N]:
         if not isinstance(node, str):
@@ -51,32 +79,70 @@ class Graph(Generic[N, E]):
         def _predecessors():
             return self._g.get_predecessors(node)
 
-        return _ReadOnlyMappingInOrderAsIterable(_predecessors, self._node_data)
+        return self._get_node_mapping(_predecessors)
+
+    def _get_node_mapping(self, keys: Callable[[], Iterable[str]]) -> Mapping[str, N]:
+        return _ReadOnlyMappingInOrderAsIterable(keys, self._node_data, self._node_fn)
+
+    def _get_edge_mapping(
+        self, keys: Callable[[], Iterable[tuple[str, str]]]
+    ) -> Mapping[tuple[str, str], E]:
+        return _ReadOnlyMappingInOrderAsIterable(keys, self._edge_data, self._edge_fn)
 
     @property
     def nodes(self) -> Mapping[str, N]:
-        return _ReadOnlyMappingInOrderAsIterable(self._g.iter_nodes, self._node_data)
+        return self._get_node_mapping(self._g.iter_nodes)
 
     @property
     def edges(self) -> Mapping[tuple[str, str], E]:
-        return _ReadOnlyMappingInOrderAsIterable(self._g.iter_edges, self._edge_data)
+        return self._get_edge_mapping(self._g.iter_edges)
 
-    def iter_bfs_down_from(self, node: str) -> Iterator[N]:
-        nodes = self.nodes
-        for name in bfs_iter_down(
-            self._g.get_predecessors, self._g.get_successors, node
-        ):
-            yield nodes[name]
+    def iter_bfs_down_from(self, node: str) -> Mapping[str, N]:
+        def iter_keys():
+            return bfs_iter_down(self._g.get_successors, node)
 
-    def iter_bfs_up_from(self, node: str) -> Iterator[N]:
-        nodes = self.nodes
-        for name in bfs_iter_up(self._g.get_predecessors, self._g.get_successors, node):
-            yield nodes[name]
+        return self._get_node_mapping(iter_keys)
 
-    def iter_dfs_preorder_down_from(self, node: str) -> Iterator[N]:
-        nodes = self.nodes
-        for name in dfs_pre_order(self._g.get_successors, node):
-            yield nodes[name]
+    def iter_bfs_up_from(self, node: str) -> Mapping[str, N]:
+        def iter_keys():
+            return bfs_iter_up(self._g.get_predecessors, self._g.get_successors, node)
+
+        return self._get_node_mapping(iter_keys)
+
+    def iter_dfs_preorder_down_from(self, node: str) -> Mapping[str, N]:
+        def iter_keys():
+            return dfs_pre_order(self._g.get_successors, node)
+
+        return self._get_node_mapping(iter_keys)
+
+    def as_dict(self) -> dict:
+        data = self.data.copy()
+        data["nodes"] = list(data["nodes"].values())
+        data["edges"] = list(data["edges"].values())
+        return data
+
+    @classmethod
+    def from_dict(
+        cls,
+        d: dict[str, Any],
+        node_fn: Callable[[dict], N] = Node,
+        edge_fn: Callable[[dict], E] = Edge,
+    ) -> "Graph[N, E]":
+        data = d.copy()
+        data["nodes"] = {node["name"]: node for node in data["nodes"]}
+        data["edges"] = {(edge["src"], edge["sink"]): edge for edge in data["edges"]}
+        g = cls(node_fn=node_fn, edge_fn=edge_fn, data=data)
+        return g
+
+    def load_dict(self, data: dict[str, Any]) -> None:
+        """override the current state with the state from `data`.
+
+        Use this if you want to change the underlying data structure
+        for an already existing graph, e.g., because you want to reuse
+        the set `node_fn`, `edge_fn` functions for constructing
+        nodes and edges.
+        """
+        self.data = data.copy()
 
 
 _K = TypeVar("_K")
@@ -84,9 +150,15 @@ _V = TypeVar("_V")
 
 
 class _ReadOnlyMappingInOrderAsIterable(Mapping[_K, _V]):
-    def __init__(self, iterable: Callable[[], Iterator[_K]], d: dict[_K, _V]):
+    def __init__(
+        self,
+        iterable: Callable[[], Iterable[_K]],
+        d: dict[_K, Any],
+        value_constructor: Callable[[Any], _V],
+    ):
         self._iterable = iterable
         self._d = d
+        self._value_constructor = value_constructor
 
     def __iter__(self) -> Iterator[_K]:
         yield from self._iterable()
@@ -98,4 +170,4 @@ class _ReadOnlyMappingInOrderAsIterable(Mapping[_K, _V]):
         return k in self._d
 
     def __getitem__(self, k: _K) -> _V:
-        return self._d[k]
+        return self._value_constructor(self._d[k])

--- a/tests/unit_tests/ir/graph_test.py
+++ b/tests/unit_tests/ir/graph_test.py
@@ -37,9 +37,9 @@ def test_edges_is_read_only(graph) -> None:
 
 def test_predecessors_of_z_is_y(graph) -> None:
     n = next(iter(graph.predecessors("z").values()))
-    assert graph.nodes["y"] is n
+    assert graph.nodes["y"] == n
 
 
 def test_successor_of_x_is_y(graph) -> None:
     n = next(iter(graph.successors("x").values()))
-    assert graph.nodes["y"] is n
+    assert graph.nodes["y"] == n

--- a/tests/unit_tests/ir/ir_data_graph_test.py
+++ b/tests/unit_tests/ir/ir_data_graph_test.py
@@ -1,0 +1,30 @@
+from elasticai.creator.ir import Edge, Node, edge, node
+from elasticai.creator.ir import Graph as _Graph
+
+
+class Graph(_Graph[Node, Edge]):
+    name: str
+    type: str
+
+
+def test_graph_is_serialized():
+    g = Graph(data=dict(name="network", type="network"), node_fn=Node, edge_fn=Edge)
+    g.add_node(node(name="node1", type="type1"))
+    g.add_node(node(name="node2", type="type2"))
+    g.add_edge(edge(src="node1", sink="node2"))
+    assert g.data == {
+        "name": "network",
+        "type": "network",
+        "nodes": {
+            "node1": {"name": "node1", "type": "type1"},
+            "node2": {"name": "node2", "type": "type2"},
+        },
+        "edges": {
+            ("node1", "node2"): {"src": "node1", "sink": "node2"},
+        },
+    }
+
+
+def test_graph_has_required_fields():
+    g = Graph(data=dict(name="network", type="network"), node_fn=Node, edge_fn=Edge)
+    assert g.name == "network"

--- a/tests/unit_tests/ir2vhd_test.py
+++ b/tests/unit_tests/ir2vhd_test.py
@@ -2,8 +2,8 @@ from typing import Any
 
 from pytest import fixture
 
-from elasticai.creator.ir import Node
 from elasticai.creator.ir2vhdl import (
+    Edge,
     Implementation,
     Instance,
     LogicSignal,
@@ -19,12 +19,15 @@ from elasticai.creator.ir2vhdl import (
 
 @fixture
 def impl() -> Implementation:
-    return Implementation(
+    impl: Implementation[VhdlNode, Edge] = Implementation(
         name="conv1",
         type="conv",
-        attributes={"a": 1},
-        nodes=(Node(dict(name="x", type="y")),),
+        data={"a": 1},
     )
+    impl.add_node(
+        VhdlNode(dict(name="x", type="y")),
+    )
+    return impl
 
 
 @fixture
@@ -36,16 +39,16 @@ def data() -> dict[str, Any]:
             {"name": "x", "type": "y"},
         ],
         "edges": [],
-        "attributes": {"a": 1},
+        "a": 1,
     }
 
 
 def test_store_as_dict(data, impl):
-    assert data == impl.asdict()
+    assert data == impl.as_dict()
 
 
 def test_load_from_dict(data):
-    assert data == Implementation.fromdict(data).asdict()
+    assert data == Implementation.from_dict(data).as_dict()
 
 
 def test_can_access_attributes_of_vhdl_node():


### PR DESCRIPTION
The change makes the ir.Graph type more usable
out of the box.
Most importantly serialization/deserialization
routines can be used for subclasses as well.

Disadvantages:

* cannot inherit from ABC at the same time
* stronger coupling to IrData as this is package internal I do not consider this to be a big drawback

Advantages:

* easier access to custom attributes (see IrData)
* a common serialization/deserialization routine for all subclasses
* encourages composition instead of inheritance for uses beyond adding custom attribute fields
* increased consistency in the ir package as all exported types are now based on IrData



* Closes: #530

BREAKING CHANGE: Might break clients that were using `asdict` `fromdict` methods of `ir2vhdl.Implementation` previously. Clients using the old version of the
Graph constructor will receive a deprecation warning.