### PR TITLE
docs: add GitHub repository link to documentation header

### DIFF
--- a/docs/supplemental-ui/partials/header-content.hbs
+++ b/docs/supplemental-ui/partials/header-content.hbs
@@ -15,5 +15,11 @@
         <span></span>
       </button>
     </div>
+      <div class="navbar-end">
+      <!-- GitHub Repository Link -->
+      <a class="navbar-item" href="https://github.com/es-ude/elastic-ai.creator" target="_blank" title="View GitHub Repository">
+        <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" style="width: 24px; height: 24px;">
+      </a>
+    </div>
   </nav>
 </header>


### PR DESCRIPTION
Added a GitHub repository link in the navigation bar of the documentation header (`header-content.hbs`)  
to improve accessibility and provide an easy way for users to navigate to the project repository.

fixes #504 