### PR TITLE
feat(vhdl-plugins): add counter

### DIFF
--- a/docs/apidocs/elasticai.creator/elasticai.creator.ir2vhdl.testing.md
+++ b/docs/apidocs/elasticai.creator/elasticai.creator.ir2vhdl.testing.md
@@ -1,0 +1,31 @@
+# {py:mod}`elasticai.creator.ir2vhdl.testing`
+
+```{py:module} elasticai.creator.ir2vhdl.testing
+```
+
+```{autodoc2-docstring} elasticai.creator.ir2vhdl.testing
+:allowtitles:
+```
+
+## Package Contents
+
+### Functions
+
+````{list-table}
+:class: autosummary longtable
+:align: left
+
+* - {py:obj}`run_vunit_vhdl_testbenches <elasticai.creator.ir2vhdl.testing.testing.run_vunit_vhdl_testbenches>`
+  - ```{autodoc2-docstring} elasticai.creator.ir2vhdl.testing.testing.run_vunit_vhdl_testbenches
+    :summary:
+    ```
+````
+
+### API
+
+````{py:function} run_vunit_vhdl_testbenches(deps: list[str], test_dir: pathlib.Path | str)
+:canonical: elasticai.creator.ir2vhdl.testing.testing.run_vunit_vhdl_testbenches
+
+```{autodoc2-docstring} elasticai.creator.ir2vhdl.testing.testing.run_vunit_vhdl_testbenches
+```
+````

--- a/docs/apidocs/elasticai.creator/elasticai.creator.ir2vhdl.testing.testing.md
+++ b/docs/apidocs/elasticai.creator/elasticai.creator.ir2vhdl.testing.testing.md
@@ -1,0 +1,31 @@
+# {py:mod}`elasticai.creator.ir2vhdl.testing.testing`
+
+```{py:module} elasticai.creator.ir2vhdl.testing.testing
+```
+
+```{autodoc2-docstring} elasticai.creator.ir2vhdl.testing.testing
+:allowtitles:
+```
+
+## Module Contents
+
+### Functions
+
+````{list-table}
+:class: autosummary longtable
+:align: left
+
+* - {py:obj}`run_vunit_vhdl_testbenches <elasticai.creator.ir2vhdl.testing.testing.run_vunit_vhdl_testbenches>`
+  - ```{autodoc2-docstring} elasticai.creator.ir2vhdl.testing.testing.run_vunit_vhdl_testbenches
+    :summary:
+    ```
+````
+
+### API
+
+````{py:function} run_vunit_vhdl_testbenches(deps: list[str], test_dir: pathlib.Path | str)
+:canonical: elasticai.creator.ir2vhdl.testing.testing.run_vunit_vhdl_testbenches
+
+```{autodoc2-docstring} elasticai.creator.ir2vhdl.testing.testing.run_vunit_vhdl_testbenches
+```
+````

--- a/docs/apidocs/elasticai.creator_plugins.counter/elasticai.creator_plugins.counter.md
+++ b/docs/apidocs/elasticai.creator_plugins.counter/elasticai.creator_plugins.counter.md
@@ -1,0 +1,34 @@
+# {py:mod}`elasticai.creator_plugins.counter`
+
+```{py:module} elasticai.creator_plugins.counter
+```
+
+```{autodoc2-docstring} elasticai.creator_plugins.counter
+:allowtitles:
+```
+
+## Package Contents
+
+### Data
+
+````{list-table}
+:class: autosummary longtable
+:align: left
+
+* - {py:obj}`META <elasticai.creator_plugins.counter.META>`
+  - ```{autodoc2-docstring} elasticai.creator_plugins.counter.META
+    :summary:
+    ```
+````
+
+### API
+
+````{py:data} META
+:canonical: elasticai.creator_plugins.counter.META
+:value: >
+   'dict(...)'
+
+```{autodoc2-docstring} elasticai.creator_plugins.counter.META
+```
+
+````

--- a/docs/apidocs/index.rst
+++ b/docs/apidocs/index.rst
@@ -9,5 +9,6 @@ This page contains auto-generated API reference documentation [#f1]_.
    elasticai.creator/elasticai.creator
    elasticai.creator_plugins.middleware/elasticai.creator_plugins.middleware
    elasticai.creator_plugins.skeleton/elasticai.creator_plugins.skeleton
+   elasticai.creator_plugins.counter/elasticai.creator_plugins.counter
 
 .. [#f1] Created with `sphinx-autodoc2 <https://github.com/chrisjsewell/sphinx-autodoc2>`_

--- a/docs/creator/index.md
+++ b/docs/creator/index.md
@@ -1,5 +1,7 @@
 # Creator
 
+
+
 ```{include} ../../README.md
 :start-line: 2
 :end-line: 13
@@ -15,6 +17,7 @@ plugin-system.md
 skeleton.md
 system_integrations.md
 quantized_grads.md
+plugins/index
 ../apidocs/index.rst
 ```
 

--- a/docs/creator/plugins/counter.md
+++ b/docs/creator/plugins/counter.md
@@ -1,0 +1,2 @@
+```{include} ../../../elasticai/creator_plugins/counter/README.md
+```

--- a/docs/creator/plugins/index.md
+++ b/docs/creator/plugins/index.md
@@ -1,3 +1,7 @@
+# Builtin Plugins
+
+
 ```{toctree}
 
+counter
 ```

--- a/elasticai/creator/ir2vhdl/testing/__init__.py
+++ b/elasticai/creator/ir2vhdl/testing/__init__.py
@@ -1,0 +1,3 @@
+from .testing import run_vunit_vhdl_testbenches
+
+__all__ = ["run_vunit_vhdl_testbenches"]

--- a/elasticai/creator/ir2vhdl/testing/testing.py
+++ b/elasticai/creator/ir2vhdl/testing/testing.py
@@ -1,0 +1,27 @@
+from importlib import resources
+from logging import getLogger
+from pathlib import Path
+
+from vunit import VUnit
+
+
+def run_vunit_vhdl_testbenches(deps: list[str], test_dir: Path | str):
+    logger = getLogger(__name__)
+    if isinstance(test_dir, str):
+        test_dir = Path(test_dir)
+    test_dir = test_dir.absolute()
+    logger.info("using test_dir {}".format(test_dir))
+    vu = VUnit.from_argv([])
+    vu.add_vhdl_builtins()
+    lib = vu.add_library("lib")
+    for testbench in test_dir.glob("*_tb.vhd"):
+        logger.info("adding testbench {}".format(testbench))
+        lib.add_source_file(testbench.absolute())
+
+    for dep in deps:
+        vhdl_dir = resources.files(dep).joinpath("vhdl")
+        if not vhdl_dir.is_dir():
+            raise IOError("could not find directory under {}".format(vhdl_dir))
+        for file in vhdl_dir.glob("*.vhd"):  # type: ignore
+            lib.add_source_files(str(file.absolute()))
+    vu.main()

--- a/elasticai/creator_plugins/counter/README.md
+++ b/elasticai/creator_plugins/counter/README.md
@@ -1,0 +1,27 @@
+# Counter
+
+The plugin provides a counter implemented in vhdl.
+
+:::
+#### Interface
+:::
+
+```vhdl
+entity counter is
+    generic (
+        MAX_VALUE : natural  -- <1>
+    );
+    port (
+        clk : in std_logic;
+        rst : in std_logic;  -- <2>
+        enable : in std_logic := '0';  -- <3>
+        d_out : out std_logic_vector(clog2(MAX_VALUE+1) - 1 downto 0) := (others => '0') -- <4>
+    );
+end entity;
+```
+1. The maximum value of the counter. After reaching this value, the counter will reset to 0 when reaching the end of the process (ie. on the next change of `clk`).
+2. Holding the reset signal will reset the counter to 0.
+3. The counter will increment on each rising edge of the clock signal while the enable signal is high.
+4. The output of the counter as a `std_logic_vector`.
+Use `to_unsigned(0, d_out'length)` to turn this into an unsigned number again.
+

--- a/elasticai/creator_plugins/counter/__init__.py
+++ b/elasticai/creator_plugins/counter/__init__.py
@@ -1,0 +1,1 @@
+META = dict(version="0.1", static_components=("counter",))

--- a/elasticai/creator_plugins/counter/docs/antora.yml
+++ b/elasticai/creator_plugins/counter/docs/antora.yml
@@ -1,0 +1,5 @@
+name: counter
+version: true
+title: Counter
+nav:
+ - modules/ROOT/nav.adoc

--- a/elasticai/creator_plugins/counter/meta.toml
+++ b/elasticai/creator_plugins/counter/meta.toml
@@ -1,0 +1,10 @@
+
+[[plugins]]
+name = 'counter'
+version = '0.1'
+api_version = '0.1'
+target_runtime = 'vhdl'
+target_platform = ''
+generated = []
+static_files = ["counter.vhd"]
+

--- a/elasticai/creator_plugins/counter/tests/counter_tb.vhd
+++ b/elasticai/creator_plugins/counter/tests/counter_tb.vhd
@@ -1,0 +1,80 @@
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+use ieee.numeric_std.all;
+use ieee.math_real.all;
+use work.counter_pkg.all;
+use std.env.all;
+
+library vunit_lib;
+context vunit_lib.vunit_context;
+
+entity counter_tb is
+  generic (runner_cfg : string);
+end counter_tb;
+
+architecture Behavioral of counter_tb is
+    signal rst : std_logic := '0';
+    signal enable : std_logic := '0';
+    signal d_counter : std_logic_vector(4 - 1 downto 0);
+    signal clk : std_logic := '0';
+    signal wrap_arounds : unsigned(8 -1 downto 0) := to_unsigned(0, 8);
+    constant clk_freq : time := 2 ps;
+    constant clk_cycle : time := 2 * clk_freq;
+begin
+
+    clk <= not clk after clk_freq;
+
+
+    dut_i : entity work.counter(rtl) 
+        generic map (MAX_VALUE => 9)
+        port map ( clk => clk, enable => enable, d_out => d_counter, rst => rst);
+        
+
+   
+   
+  process is
+    procedure count_to(constant number: natural) is
+    begin
+      rst <= '1';
+      wait for clk_cycle;
+      rst <= '0';
+      enable <= '1';
+      wait for number*clk_cycle;
+      enable <= '0';
+    end procedure;
+
+    procedure check_counter(constant number: natural) is
+      constant expected : std_logic_vector(d_counter'range) := std_logic_vector(to_unsigned(number, d_counter'length));
+    begin
+      check_equal(d_counter, expected);
+    end procedure;
+
+    procedure can_count_to(constant number: natural) is
+    begin
+      count_to(number);
+      check_counter(number);
+    end procedure;
+      
+   begin
+      test_runner_setup(runner, runner_cfg);
+      if run("can count to one") then
+        can_count_to(1);
+      end if;
+
+      if run("can count to two") then
+        can_count_to(2);
+      end if;
+
+      if run("can count to max value 9") then
+        can_count_to(9);
+      end if;
+
+      if run("counter wraps at 9") then
+        count_to(10);
+        check_counter(0);
+      end if;
+
+      test_runner_cleanup(runner);
+   end process;
+
+end Behavioral;

--- a/elasticai/creator_plugins/counter/tests/run_tbs.py
+++ b/elasticai/creator_plugins/counter/tests/run_tbs.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+from elasticai.creator.ir2vhdl.testing import run_vunit_vhdl_testbenches
+
+if __name__ == "__main__":
+    run_vunit_vhdl_testbenches(
+        ["elasticai.creator_plugins.counter"], test_dir=Path(__file__).parent
+    )

--- a/elasticai/creator_plugins/counter/vhdl/counter.vhd
+++ b/elasticai/creator_plugins/counter/vhdl/counter.vhd
@@ -1,0 +1,64 @@
+library ieee;
+USE ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.math_real.all;
+
+package counter_pkg is
+  function clog2(n : positive) return positive;
+ end package;
+ 
+ package body counter_pkg is
+ 
+    function clog2(n : positive) return positive is
+    begin
+        return positive(ceil(log2(real(n))));
+    end function;
+    
+ end package body;
+    
+
+library ieee;
+USE ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.math_real.all;
+use work.counter_pkg.all;
+
+
+entity counter is
+    generic (
+        MAX_VALUE : natural 
+    );
+    port (
+        clk : in std_logic;
+        rst : in std_logic; 
+        enable : in std_logic := '0'; 
+        d_out : out std_logic_vector(clog2(MAX_VALUE+1) - 1 downto 0) := (others => '0')
+    );
+end entity;
+
+architecture rtl of counter is
+
+    signal count_r : unsigned(d_out'range) := to_unsigned(0, d_out'length);
+
+begin
+    d_out <= std_logic_vector(count_r);
+
+
+    process (clk, rst) is
+    begin
+        if (rst = '1') then
+            count_r <= to_unsigned(0, count_r'length);
+        elsif (rising_edge(clk)) then
+            if (enable = '1') then
+                if (count_r = MAX_VALUE) then
+                    count_r <= to_unsigned(0, count_r'length);
+                else
+                    count_r <= count_r + 1;
+                end if;
+            end if;
+        end if;
+    
+    end process;    
+
+
+end architecture;


### PR DESCRIPTION
Adds a simple counter design. You can
set a maximum value as a generic
parameter. Counter will reset to 0
after reaching the maximum.

The component will be used,
e.g., to implement filters
with stride higher than one
and to find out if a buffer
has been filled with valid
data.