### PR TITLE
feat(torch2ir): support simple torch 2 ir conversion w/o model state

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -153,7 +153,7 @@ in {
         if $CI; then
           ${pkgs.cocogitto}/bin/cog check ..$GITHUB_SOURCE_REF
         else
-          ${pkgs.cocogitto}/bin/cog check
+          ${pkgs.cocogitto}/bin/cog check --from-latest-tag --ignore-merge-commits
         fi
       '';
       before = ["check:all"];

--- a/docs/apidocs/elasticai.creator/elasticai.creator.md
+++ b/docs/apidocs/elasticai.creator/elasticai.creator.md
@@ -17,6 +17,7 @@ elasticai.creator.nn
 elasticai.creator.ir
 elasticai.creator.vhdl
 elasticai.creator.base_modules
+elasticai.creator.torch2ir
 elasticai.creator.ir2vhdl
 elasticai.creator.file_generation
 ```

--- a/docs/apidocs/elasticai.creator/elasticai.creator.torch2ir.core.md
+++ b/docs/apidocs/elasticai.creator/elasticai.creator.torch2ir.core.md
@@ -1,0 +1,112 @@
+# {py:mod}`elasticai.creator.torch2ir.core`
+
+```{py:module} elasticai.creator.torch2ir.core
+```
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.core
+:allowtitles:
+```
+
+## Module Contents
+
+### Classes
+
+````{list-table}
+:class: autosummary longtable
+:align: left
+
+* - {py:obj}`Node <elasticai.creator.torch2ir.core.Node>`
+  -
+* - {py:obj}`Implementation <elasticai.creator.torch2ir.core.Implementation>`
+  -
+````
+
+### Functions
+
+````{list-table}
+:class: autosummary longtable
+:align: left
+
+* - {py:obj}`new_node <elasticai.creator.torch2ir.core.new_node>`
+  - ```{autodoc2-docstring} elasticai.creator.torch2ir.core.new_node
+    :summary:
+    ```
+* - {py:obj}`input_node <elasticai.creator.torch2ir.core.input_node>`
+  - ```{autodoc2-docstring} elasticai.creator.torch2ir.core.input_node
+    :summary:
+    ```
+* - {py:obj}`output_node <elasticai.creator.torch2ir.core.output_node>`
+  - ```{autodoc2-docstring} elasticai.creator.torch2ir.core.output_node
+    :summary:
+    ```
+````
+
+### API
+
+`````{py:class} Node(data: dict[str, elasticai.creator.ir.attribute.Attribute])
+:canonical: elasticai.creator.torch2ir.core.Node
+
+Bases: {py:obj}`elasticai.creator.ir.Node`
+
+````{py:attribute} implementation
+:canonical: elasticai.creator.torch2ir.core.Node.implementation
+:type: str
+:value: >
+   None
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.core.Node.implementation
+```
+
+````
+
+`````
+
+````{py:function} new_node(name: str, type: str, implementation: str, attributes: dict[str, typing.Any] | None = None) -> elasticai.creator.torch2ir.core.Node
+:canonical: elasticai.creator.torch2ir.core.new_node
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.core.new_node
+```
+````
+
+````{py:function} input_node(attributes: dict[str, typing.Any] | None = None) -> elasticai.creator.torch2ir.core.Node
+:canonical: elasticai.creator.torch2ir.core.input_node
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.core.input_node
+```
+````
+
+````{py:function} output_node(attributes: dict[str, typing.Any] | None = None) -> elasticai.creator.torch2ir.core.Node
+:canonical: elasticai.creator.torch2ir.core.output_node
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.core.output_node
+```
+````
+
+`````{py:class} Implementation(*, node_fn: collections.abc.Callable[[dict], elasticai.creator.ir.graph.N] = Node, edge_fn: collections.abc.Callable[[dict], elasticai.creator.ir.graph.E] = Edge, nodes: collections.abc.Iterable[elasticai.creator.ir.graph.N] = tuple(), edges: collections.abc.Iterable[elasticai.creator.ir.graph.E] = tuple(), data=None)
+:canonical: elasticai.creator.torch2ir.core.Implementation
+
+Bases: {py:obj}`elasticai.creator.ir.Graph`\[{py:obj}`elasticai.creator.torch2ir.core.Node`\, {py:obj}`elasticai.creator.ir.Edge`\]
+
+````{py:attribute} name
+:canonical: elasticai.creator.torch2ir.core.Implementation.name
+:type: str
+:value: >
+   None
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.core.Implementation.name
+```
+
+````
+
+````{py:attribute} type
+:canonical: elasticai.creator.torch2ir.core.Implementation.type
+:type: str
+:value: >
+   None
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.core.Implementation.type
+```
+
+````
+
+`````

--- a/docs/apidocs/elasticai.creator/elasticai.creator.torch2ir.default_module_handlers.md
+++ b/docs/apidocs/elasticai.creator/elasticai.creator.torch2ir.default_module_handlers.md
@@ -1,0 +1,108 @@
+# {py:mod}`elasticai.creator.torch2ir.default_module_handlers`
+
+```{py:module} elasticai.creator.torch2ir.default_module_handlers
+```
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.default_module_handlers
+:allowtitles:
+```
+
+## Module Contents
+
+### Functions
+
+````{list-table}
+:class: autosummary longtable
+:align: left
+
+* - {py:obj}`conv1d <elasticai.creator.torch2ir.default_module_handlers.conv1d>`
+  - ```{autodoc2-docstring} elasticai.creator.torch2ir.default_module_handlers.conv1d
+    :summary:
+    ```
+* - {py:obj}`maxpool1d <elasticai.creator.torch2ir.default_module_handlers.maxpool1d>`
+  - ```{autodoc2-docstring} elasticai.creator.torch2ir.default_module_handlers.maxpool1d
+    :summary:
+    ```
+* - {py:obj}`linear <elasticai.creator.torch2ir.default_module_handlers.linear>`
+  - ```{autodoc2-docstring} elasticai.creator.torch2ir.default_module_handlers.linear
+    :summary:
+    ```
+* - {py:obj}`batchnorm1d <elasticai.creator.torch2ir.default_module_handlers.batchnorm1d>`
+  - ```{autodoc2-docstring} elasticai.creator.torch2ir.default_module_handlers.batchnorm1d
+    :summary:
+    ```
+* - {py:obj}`flatten <elasticai.creator.torch2ir.default_module_handlers.flatten>`
+  - ```{autodoc2-docstring} elasticai.creator.torch2ir.default_module_handlers.flatten
+    :summary:
+    ```
+* - {py:obj}`relu <elasticai.creator.torch2ir.default_module_handlers.relu>`
+  - ```{autodoc2-docstring} elasticai.creator.torch2ir.default_module_handlers.relu
+    :summary:
+    ```
+````
+
+### Data
+
+````{list-table}
+:class: autosummary longtable
+:align: left
+
+* - {py:obj}`handlers <elasticai.creator.torch2ir.default_module_handlers.handlers>`
+  - ```{autodoc2-docstring} elasticai.creator.torch2ir.default_module_handlers.handlers
+    :summary:
+    ```
+````
+
+### API
+
+````{py:data} handlers
+:canonical: elasticai.creator.torch2ir.default_module_handlers.handlers
+:value: >
+   []
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.default_module_handlers.handlers
+```
+
+````
+
+````{py:function} conv1d(module: torch.nn.Conv1d) -> dict
+:canonical: elasticai.creator.torch2ir.default_module_handlers.conv1d
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.default_module_handlers.conv1d
+```
+````
+
+````{py:function} maxpool1d(module: torch.nn.MaxPool1d) -> dict
+:canonical: elasticai.creator.torch2ir.default_module_handlers.maxpool1d
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.default_module_handlers.maxpool1d
+```
+````
+
+````{py:function} linear(module: torch.nn.Linear) -> dict
+:canonical: elasticai.creator.torch2ir.default_module_handlers.linear
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.default_module_handlers.linear
+```
+````
+
+````{py:function} batchnorm1d(module: torch.nn.BatchNorm1d) -> dict
+:canonical: elasticai.creator.torch2ir.default_module_handlers.batchnorm1d
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.default_module_handlers.batchnorm1d
+```
+````
+
+````{py:function} flatten(module: torch.nn.Flatten) -> dict
+:canonical: elasticai.creator.torch2ir.default_module_handlers.flatten
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.default_module_handlers.flatten
+```
+````
+
+````{py:function} relu(module: torch.nn.ReLU) -> dict
+:canonical: elasticai.creator.torch2ir.default_module_handlers.relu
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.default_module_handlers.relu
+```
+````

--- a/docs/apidocs/elasticai.creator/elasticai.creator.torch2ir.md
+++ b/docs/apidocs/elasticai.creator/elasticai.creator.torch2ir.md
@@ -1,0 +1,163 @@
+# {py:mod}`elasticai.creator.torch2ir`
+
+```{py:module} elasticai.creator.torch2ir
+```
+
+```{autodoc2-docstring} elasticai.creator.torch2ir
+:allowtitles:
+```
+
+## Package Contents
+
+### Classes
+
+````{list-table}
+:class: autosummary longtable
+:align: left
+
+* - {py:obj}`Torch2Ir <elasticai.creator.torch2ir.torch2ir.Torch2Ir>`
+  - ```{autodoc2-docstring} elasticai.creator.torch2ir.torch2ir.Torch2Ir
+    :summary:
+    ```
+* - {py:obj}`Implementation <elasticai.creator.torch2ir.core.Implementation>`
+  -
+* - {py:obj}`Node <elasticai.creator.torch2ir.core.Node>`
+  -
+````
+
+### Functions
+
+````{list-table}
+:class: autosummary longtable
+:align: left
+
+* - {py:obj}`new_node <elasticai.creator.torch2ir.core.new_node>`
+  - ```{autodoc2-docstring} elasticai.creator.torch2ir.core.new_node
+    :summary:
+    ```
+* - {py:obj}`input_node <elasticai.creator.torch2ir.core.input_node>`
+  - ```{autodoc2-docstring} elasticai.creator.torch2ir.core.input_node
+    :summary:
+    ```
+* - {py:obj}`output_node <elasticai.creator.torch2ir.core.output_node>`
+  - ```{autodoc2-docstring} elasticai.creator.torch2ir.core.output_node
+    :summary:
+    ```
+````
+
+### API
+
+`````{py:class} Torch2Ir(tracer: torch.fx.Tracer = _DefaultTracer())
+:canonical: elasticai.creator.torch2ir.torch2ir.Torch2Ir
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.torch2ir.Torch2Ir
+```
+
+```{rubric} Initialization
+```
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.torch2ir.Torch2Ir.__init__
+```
+
+````{py:method} register_module_handler(module_type: str, handler: collections.abc.Callable[[torch.nn.Module], dict]) -> None
+:canonical: elasticai.creator.torch2ir.torch2ir.Torch2Ir.register_module_handler
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.torch2ir.Torch2Ir.register_module_handler
+```
+
+````
+
+````{py:method} register_module_handlers(handlers: collections.abc.Iterable[collections.abc.Callable[[torch.nn.Module], dict]]) -> elasticai.creator.torch2ir.torch2ir.Torch2Ir
+:canonical: elasticai.creator.torch2ir.torch2ir.Torch2Ir.register_module_handlers
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.torch2ir.Torch2Ir.register_module_handlers
+```
+
+````
+
+````{py:method} convert(model: torch.nn.Module) -> dict[str, elasticai.creator.torch2ir.core.Implementation]
+:canonical: elasticai.creator.torch2ir.torch2ir.Torch2Ir.convert
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.torch2ir.Torch2Ir.convert
+```
+
+````
+
+````{py:method} get_default_converter() -> elasticai.creator.torch2ir.torch2ir.Torch2Ir
+:canonical: elasticai.creator.torch2ir.torch2ir.Torch2Ir.get_default_converter
+:classmethod:
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.torch2ir.Torch2Ir.get_default_converter
+```
+
+````
+
+`````
+
+`````{py:class} Implementation(*, node_fn: collections.abc.Callable[[dict], elasticai.creator.ir.graph.N] = Node, edge_fn: collections.abc.Callable[[dict], elasticai.creator.ir.graph.E] = Edge, nodes: collections.abc.Iterable[elasticai.creator.ir.graph.N] = tuple(), edges: collections.abc.Iterable[elasticai.creator.ir.graph.E] = tuple(), data=None)
+:canonical: elasticai.creator.torch2ir.core.Implementation
+
+Bases: {py:obj}`elasticai.creator.ir.Graph`\[{py:obj}`elasticai.creator.torch2ir.core.Node`\, {py:obj}`elasticai.creator.ir.Edge`\]
+
+````{py:attribute} name
+:canonical: elasticai.creator.torch2ir.core.Implementation.name
+:type: str
+:value: >
+   None
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.core.Implementation.name
+```
+
+````
+
+````{py:attribute} type
+:canonical: elasticai.creator.torch2ir.core.Implementation.type
+:type: str
+:value: >
+   None
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.core.Implementation.type
+```
+
+````
+
+`````
+
+`````{py:class} Node(data: dict[str, elasticai.creator.ir.attribute.Attribute])
+:canonical: elasticai.creator.torch2ir.core.Node
+
+Bases: {py:obj}`elasticai.creator.ir.Node`
+
+````{py:attribute} implementation
+:canonical: elasticai.creator.torch2ir.core.Node.implementation
+:type: str
+:value: >
+   None
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.core.Node.implementation
+```
+
+````
+
+`````
+
+````{py:function} new_node(name: str, type: str, implementation: str, attributes: dict[str, typing.Any] | None = None) -> elasticai.creator.torch2ir.core.Node
+:canonical: elasticai.creator.torch2ir.core.new_node
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.core.new_node
+```
+````
+
+````{py:function} input_node(attributes: dict[str, typing.Any] | None = None) -> elasticai.creator.torch2ir.core.Node
+:canonical: elasticai.creator.torch2ir.core.input_node
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.core.input_node
+```
+````
+
+````{py:function} output_node(attributes: dict[str, typing.Any] | None = None) -> elasticai.creator.torch2ir.core.Node
+:canonical: elasticai.creator.torch2ir.core.output_node
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.core.output_node
+```
+````

--- a/docs/apidocs/elasticai.creator/elasticai.creator.torch2ir.torch2ir.md
+++ b/docs/apidocs/elasticai.creator/elasticai.creator.torch2ir.torch2ir.md
@@ -1,0 +1,78 @@
+# {py:mod}`elasticai.creator.torch2ir.torch2ir`
+
+```{py:module} elasticai.creator.torch2ir.torch2ir
+```
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.torch2ir
+:allowtitles:
+```
+
+## Module Contents
+
+### Classes
+
+````{list-table}
+:class: autosummary longtable
+:align: left
+
+* - {py:obj}`Torch2Ir <elasticai.creator.torch2ir.torch2ir.Torch2Ir>`
+  - ```{autodoc2-docstring} elasticai.creator.torch2ir.torch2ir.Torch2Ir
+    :summary:
+    ```
+````
+
+### API
+
+```{py:exception} LoweringError(message: str)
+:canonical: elasticai.creator.torch2ir.torch2ir.LoweringError
+
+Bases: {py:obj}`Exception`
+
+```
+
+`````{py:class} Torch2Ir(tracer: torch.fx.Tracer = _DefaultTracer())
+:canonical: elasticai.creator.torch2ir.torch2ir.Torch2Ir
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.torch2ir.Torch2Ir
+```
+
+```{rubric} Initialization
+```
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.torch2ir.Torch2Ir.__init__
+```
+
+````{py:method} register_module_handler(module_type: str, handler: collections.abc.Callable[[torch.nn.Module], dict]) -> None
+:canonical: elasticai.creator.torch2ir.torch2ir.Torch2Ir.register_module_handler
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.torch2ir.Torch2Ir.register_module_handler
+```
+
+````
+
+````{py:method} register_module_handlers(handlers: collections.abc.Iterable[collections.abc.Callable[[torch.nn.Module], dict]]) -> elasticai.creator.torch2ir.torch2ir.Torch2Ir
+:canonical: elasticai.creator.torch2ir.torch2ir.Torch2Ir.register_module_handlers
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.torch2ir.Torch2Ir.register_module_handlers
+```
+
+````
+
+````{py:method} convert(model: torch.nn.Module) -> dict[str, elasticai.creator.torch2ir.core.Implementation]
+:canonical: elasticai.creator.torch2ir.torch2ir.Torch2Ir.convert
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.torch2ir.Torch2Ir.convert
+```
+
+````
+
+````{py:method} get_default_converter() -> elasticai.creator.torch2ir.torch2ir.Torch2Ir
+:canonical: elasticai.creator.torch2ir.torch2ir.Torch2Ir.get_default_converter
+:classmethod:
+
+```{autodoc2-docstring} elasticai.creator.torch2ir.torch2ir.Torch2Ir.get_default_converter
+```
+
+````
+
+`````

--- a/elasticai/creator/torch2ir/__init__.py
+++ b/elasticai/creator/torch2ir/__init__.py
@@ -1,0 +1,36 @@
+"""Transform PyTorch models to IR.
+
+The translation process is highly customizable.
+(`Torch2Ir`)[elasticai.creator.torch2ir.Torch2Ir] is responsible
+for the translation process and will call *module handlers* to
+extract attributes from modules. These attributes are then
+attached to the corresponding nodes in the IR.
+
+Each module handler is a function that takes a PyTorch module
+and returns a dictionary with the extracted attributes.
+
+The `Torch2Ir` class features some factory methods as class
+methods, e.g., (`Torch2Ir.get_default_converter`)[elasticai.creator.torch2ir.Torch2Ir.get_default_converter].
+Those will create a new `Torch2Ir` instance and register some
+preconfigured module handlers.
+However, you are free to extend or alter the behaviour of the
+translation process by registering your own module handlers.
+"""
+
+from elasticai.creator.ir import edge as new_edge
+
+from .core import Edge, Implementation, Node, input_node, new_node, output_node
+from .torch2ir import (
+    Torch2Ir,
+)
+
+__all__ = [
+    "Torch2Ir",
+    "Implementation",
+    "Node",
+    "Edge",
+    "new_node",
+    "new_edge",
+    "input_node",
+    "output_node",
+]

--- a/elasticai/creator/torch2ir/core.py
+++ b/elasticai/creator/torch2ir/core.py
@@ -1,0 +1,32 @@
+from typing import Any
+
+from elasticai.creator.ir import Edge, Graph
+from elasticai.creator.ir import Node as _Node
+from elasticai.creator.ir import node as _node
+
+
+class Node(_Node):
+    implementation: str
+
+
+def new_node(
+    name: str, type: str, implementation: str, attributes: dict[str, Any] | None = None
+) -> Node:
+    if attributes is None:
+        attributes = {}
+    return Node(
+        _node(name, type, dict(implementation=implementation) | attributes).data
+    )
+
+
+def input_node(attributes: dict[str, Any] | None = None) -> Node:
+    return new_node("input", "input", "input", attributes)
+
+
+def output_node(attributes: dict[str, Any] | None = None) -> Node:
+    return new_node("output", "output", "output", attributes)
+
+
+class Implementation(Graph[Node, Edge]):
+    name: str
+    type: str

--- a/elasticai/creator/torch2ir/default_module_handlers.py
+++ b/elasticai/creator/torch2ir/default_module_handlers.py
@@ -1,0 +1,62 @@
+import torch.nn as nn
+
+handlers = []
+
+
+def _register(fn):
+    handlers.append(fn)
+    return fn
+
+
+@_register
+def conv1d(module: nn.Conv1d) -> dict:
+    return {
+        "in_channels": module.in_channels,
+        "out_channels": module.out_channels,
+        "kernel_size": module.kernel_size,
+        "stride": module.stride,
+        "padding": module.padding,
+        "dilation": module.dilation,
+        "groups": module.groups,
+        "bias": module.bias is not None,
+        "padding_mode": module.padding_mode,
+    }
+
+
+@_register
+def maxpool1d(module: nn.MaxPool1d) -> dict:
+    return {
+        "kernel_size": module.kernel_size,
+        "stride": module.stride,
+        "padding": module.padding,
+        "dilation": module.dilation,
+        "return_indices": module.return_indices,
+        "ceil_mode": module.ceil_mode,
+    }
+
+
+@_register
+def linear(module: nn.Linear) -> dict:
+    return {
+        "in_features": module.in_features,
+        "out_features": module.out_features,
+        "bias": module.bias is not None,
+    }
+
+
+@_register
+def batchnorm1d(module: nn.BatchNorm1d) -> dict:
+    return {
+        "num_features": module.num_features,
+        "affine": module.affine,
+    }
+
+
+@_register
+def flatten(module: nn.Flatten) -> dict:
+    return {}
+
+
+@_register
+def relu(module: nn.ReLU) -> dict:
+    return {}

--- a/elasticai/creator/torch2ir/torch2ir.py
+++ b/elasticai/creator/torch2ir/torch2ir.py
@@ -1,0 +1,130 @@
+from collections.abc import Callable, Iterable
+from typing import cast
+
+from torch.fx import Node as FxNode
+from torch.fx import Tracer
+from torch.nn import Module
+
+from elasticai.creator.function_utils import KeyedFunctionDispatcher
+
+from .core import Edge, Implementation, Node, new_node
+from .default_module_handlers import handlers as default_handlers
+
+
+class _DefaultTracer(Tracer):
+    def is_leaf_module(self, m, module_qualified_name):
+        if type(m).__qualname__.startswith("elasticai"):
+            return True
+        return super().is_leaf_module(m, module_qualified_name)
+
+
+class LoweringError(Exception):
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
+class Torch2Ir:
+    def __init__(self, tracer: Tracer = _DefaultTracer()):
+        super().__init__()
+        self._tracer = tracer
+        self._registry: dict[str, Implementation] = {}
+        self._g = Implementation(node_fn=Node, edge_fn=Edge)
+        self._g.type = "module"
+        self._g.name = "root"
+        self._registry["root"] = self._g
+        self._extractors: KeyedFunctionDispatcher[Module, dict] = (
+            KeyedFunctionDispatcher(self._get_module_key)
+        )
+
+    def register_module_handler(
+        self, module_type: str, handler: Callable[[Module], dict]
+    ) -> None:
+        """The handlers are used to extract the attributes of the module"""
+        self._extractors.register(module_type, handler)
+
+    def register_module_handlers(
+        self, handlers: Iterable[Callable[[Module], dict]]
+    ) -> "Torch2Ir":
+        for handler in handlers:
+            self.register_module_handler(handler.__name__, handler)
+        return self
+
+    @staticmethod
+    def _get_module_key(module: Module) -> str:
+        return module.__class__.__name__.lower()
+
+    def convert(self, model: Module) -> dict[str, Implementation]:
+        self.model = model
+        torch_graph = self._tracer.trace(model)
+        for node in torch_graph.nodes:
+            self._handle_fx_node(node)
+        return self._registry
+
+    def _get_successors(self, node: FxNode) -> list[FxNode]:
+        return list(node.users)
+
+    def _get_type(self, node: FxNode) -> str:
+        error = LoweringError("""
+                              Cannot handle function calls or getting 
+                              attributes during translation. Please use 
+                              supported Modules to design your model
+                              and change every function call to a
+                            module call.""")
+        match node.op:
+            case "call_module":
+                return type(
+                    self.model.get_submodule(cast(str, node.target))
+                ).__name__.lower()
+
+            case "call_function":
+                raise error
+            case "placeholder":
+                return "input"
+            case "output":
+                return "output"
+            case "get_attr":
+                raise error
+            case _:
+                raise Exception(f"Unknown node type: {node.op}")
+
+    def _get_implementation(self, node: FxNode) -> str:
+        match self._get_type(node):
+            case "input":
+                return "input"
+            case "output":
+                return "output"
+            case _:
+                return cast(str, node.target)
+
+    def _handle_fx_node(self, node: FxNode) -> None:
+        ir_node = new_node(
+            name=node.name,
+            type=self._get_type(node),
+            implementation=self._get_implementation(node),
+            attributes={},
+        )
+        self._g.add_node(ir_node)
+        impl = ir_node.implementation
+        if impl not in self._registry and impl not in ("input", "output"):
+            self._registry[impl] = Implementation(
+                node_fn=Node,
+                edge_fn=Edge,
+                data=dict(
+                    name=impl, type=ir_node.type, **self._extract_attributes(node)
+                ),
+            )
+
+        for successor in self._get_successors(node):
+            self._g.add_edge(Edge(dict(src=str(node.name), sink=str(successor.name))))
+
+    def _extract_attributes(self, node: FxNode) -> dict:
+        if self._get_type(node) in ("input", "output"):
+            return {}
+        module = self.model.get_submodule(cast(str, node.target))
+        return self._extractors(module)
+
+    @classmethod
+    def get_default_converter(cls) -> "Torch2Ir":
+        converter = cls()
+        converter.register_module_handlers(default_handlers)
+        return converter

--- a/tach.toml
+++ b/tach.toml
@@ -108,7 +108,7 @@ depends_on = []
 
 [[modules ]]
 path = "elasticai.creator.ir2torch"
-depends_on = ["elasticai.creator.torch2ir", "elasticai.creator.function_utils"]
+depends_on = []
 
 [[modules ]]
 path = "elasticai.creator.torch2ir"
@@ -116,4 +116,4 @@ depends_on = ["elasticai.creator.ir", "elasticai.creator.function_utils"]
 
 [[modules ]]
 path = "<root>"
-depends_on = ["elasticai.creator.ir", "elasticai.creator.plugin", "elasticai.creator.function_utils", "elasticai.creator.ir2vhdl", "elasticai.creator.vhdl", "elasticai.creator.nn.fixed_point", "elasticai.creator.nn", "elasticai.creator.file_generation"]
+depends_on = [ "elasticai.creator.vhdl", "elasticai.creator.nn.fixed_point", "elasticai.creator.nn", "elasticai.creator.file_generation"]

--- a/tests/unit_tests/torch2ir_test.py
+++ b/tests/unit_tests/torch2ir_test.py
@@ -1,0 +1,185 @@
+import torch
+from torch.nn import Linear, ReLU, Sequential
+
+from elasticai.creator.torch2ir import Torch2Ir
+
+
+def model():
+    return Sequential(
+        Linear(1, 2),
+        ReLU(),
+    )
+
+
+def convert(model):
+    ir = Torch2Ir.get_default_converter().convert(model)
+    return {impl.name: impl.data for impl in ir.values()}
+
+
+def test_convert_linear_without_bias():
+    m = Sequential(Linear(1, 2, bias=False))
+    with torch.no_grad():
+        m.get_submodule("0").weight.mul_(0).add_(1)
+    ir = convert(m)
+    assert ir == {
+        "root": {
+            "name": "root",
+            "type": "module",
+            "nodes": {
+                "input_1": {
+                    "name": "input_1",
+                    "type": "input",
+                    "implementation": "input",
+                },
+                "_0": {
+                    "name": "_0",
+                    "type": "linear",
+                    "implementation": "0",
+                },
+                "output": {
+                    "name": "output",
+                    "type": "output",
+                    "implementation": "output",
+                },
+            },
+            "edges": {
+                ("input_1", "_0"): {"src": "input_1", "sink": "_0"},
+                ("_0", "output"): {"src": "_0", "sink": "output"},
+            },
+        },
+        "0": {
+            "name": "0",
+            "type": "linear",
+            "in_features": 1,
+            "out_features": 2,
+            "bias": False,
+            "edges": {},
+            "nodes": {},
+        },
+    }
+
+
+def test_convert_linear_to_ir():
+    m = model()
+    with torch.no_grad():
+        linear = m.get_submodule("0")
+        linear.bias.mul_(0)
+        linear.weight.mul_(0).add_(1)
+
+    assert convert(m) == {
+        "0": {
+            "type": "linear",
+            "in_features": 1,
+            "out_features": 2,
+            "bias": True,
+            "edges": {},
+            "name": "0",
+            "nodes": {},
+        },
+        "1": {
+            "type": "relu",
+            "name": "1",
+            "edges": {},
+            "nodes": {},
+        },
+        "root": {
+            "name": "root",
+            "type": "module",
+            "nodes": {
+                "input_1": {
+                    "implementation": "input",
+                    "name": "input_1",
+                    "type": "input",
+                },
+                "_0": {
+                    "name": "_0",
+                    "implementation": "0",
+                    "type": "linear",
+                },
+                "_1": {
+                    "implementation": "1",
+                    "name": "_1",
+                    "type": "relu",
+                },
+                "output": {
+                    "implementation": "output",
+                    "name": "output",
+                    "type": "output",
+                },
+            },
+            "edges": {
+                ("input_1", "_0"): {"src": "input_1", "sink": "_0"},
+                ("_0", "_1"): {"src": "_0", "sink": "_1"},
+                ("_1", "output"): {"src": "_1", "sink": "output"},
+            },
+        },
+    }
+
+
+def test_converting_model_with_batchnorm():
+    class Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.bn = torch.nn.BatchNorm1d(2)
+            self.relu = torch.nn.ReLU()
+
+        def forward(self, x):
+            return self.relu(self.bn(x))
+
+    m = Model()
+    assert convert(m) == {
+        "bn": {
+            "affine": True,
+            "edges": {},
+            "name": "bn",
+            "nodes": {},
+            "num_features": 2,
+            "type": "batchnorm1d",
+        },
+        "relu": {
+            "edges": {},
+            "name": "relu",
+            "nodes": {},
+            "type": "relu",
+        },
+        "root": {
+            "edges": {
+                ("bn", "relu"): {
+                    "sink": "relu",
+                    "src": "bn",
+                },
+                ("relu", "output"): {
+                    "sink": "output",
+                    "src": "relu",
+                },
+                ("x", "bn"): {
+                    "sink": "bn",
+                    "src": "x",
+                },
+            },
+            "name": "root",
+            "nodes": {
+                "bn": {
+                    "implementation": "bn",
+                    "name": "bn",
+                    "type": "batchnorm1d",
+                },
+                "output": {
+                    "implementation": "output",
+                    "name": "output",
+                    "type": "output",
+                },
+                "relu": {
+                    "implementation": "relu",
+                    "name": "relu",
+                    "type": "relu",
+                },
+                "x": {
+                    "implementation": "input",
+                    "name": "x",
+                    "type": "input",
+                },
+            },
+            "type": "module",
+        },
+    }


### PR DESCRIPTION
* converts pytorch models to ir including hyper parameters
* model state still has to be saved and loaded to/from dict via pytorch.