### PR TITLE
chore(pytest): add new 'slow' marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,8 @@ elasticai-runtime-env5 = { git = "https://github.com/es-ude/elastic-ai.runtime.e
 [tool.pytest.ini_options]
 minversion = "6.0"
 markers = [
-    "simulation: possibly slow running integration tests including hw simulation",
+    "simulation: possibly slow running integration tests including hw simulation, depends on ghdl being present",
+    "slow: a slow test that you would not run in tdd cycle"
 ]
 testpaths = ["elasticai/creator/", "tests", "elasticai/creator_plugins"]
 python_files = ["*_test.py", "test_*.py"]
@@ -100,7 +101,7 @@ omit = [
     "elasticai/creator/utils/_run.py",         # not testable
 ]
 source = ["elasticai/creator", "elasticai/creator_plugins"]
-command_line = "-m pytest -m 'not simulation'"
+command_line = "-m pytest -m 'not simulation and not slow'"
 
 
 [tool.ruff]


### PR DESCRIPTION
Now that we're using hypothesis there will be
tests that do not depend on hardware, but will
just run for quite long.
Those should be marked with 'slow'.
Opposed to 'simulation', 'slow' does not imply
dependence on hw simulation tools.