### PR TITLE
chore(ir): print class name in instead of class in IrData repr

### DIFF
--- a/elasticai/creator/ir/ir_data.py
+++ b/elasticai/creator/ir/ir_data.py
@@ -59,7 +59,7 @@ class IrData(metaclass=IrDataMeta, create_init=False):
         return missing
 
     def __repr__(self) -> str:
-        return f"{self.__class__} ({self.data})"
+        return f"{type(self).__name__}({self.data})"
 
     def __eq__(self, o: object) -> bool:
         if self is o:


### PR DESCRIPTION
Printing the __class__ attribute directly was
hard to parse in test outputs.
Just printing the name is shorter and easier to read.