### PR TITLE
feat(ir): support decorating methods as required fields

### DIFF
--- a/elasticai/creator/ir/__init__.py
+++ b/elasticai/creator/ir/__init__.py
@@ -11,6 +11,10 @@ __all__ = [
     "Lowerable",
     "Graph",
     "Attribute",
+    "static_required_field",
+    "read_only_field",
+    "StaticMethodField",
+    "ReadOnlyField",
 ]
 from .attribute import Attribute
 from .core import Edge, Node, edge, node
@@ -18,4 +22,11 @@ from .graph import Graph
 from .ir_data import IrData
 from .ir_data_meta import IrDataMeta
 from .lowering import Lowerable, LoweringPass
-from .required_field import RequiredField, SimpleRequiredField
+from .required_field import (
+    ReadOnlyField,
+    RequiredField,
+    SimpleRequiredField,
+    StaticMethodField,
+    read_only_field,
+    static_required_field,
+)

--- a/elasticai/creator/ir/required_field.py
+++ b/elasticai/creator/ir/required_field.py
@@ -67,11 +67,17 @@ class RequiredField(Generic[StoredT, VisibleT]):
         instance.data[self.name] = self.set_convert(value)
 
 
-class SimpleRequiredField(RequiredField[StoredT, StoredT]):
-    slots = ("get_convert", "set_convert", "name")
+class SimpleRequiredField(Generic[StoredT]):
+    slots = ("name",)
 
-    def __init__(self):
-        super().__init__(lambda x: x, lambda x: x)
+    def __set_name__(self, owner: type[HasData], name: str) -> None:
+        self.name = name
+
+    def __get__(self, instance: HasData, owner=None) -> StoredT:
+        return cast(StoredT, instance.data[self.name])
+
+    def __set__(self, instance: HasData, value: StoredT) -> None:
+        instance.data[self.name] = value
 
 
 class ReadOnlyField(Generic[StoredT, VisibleT]):
@@ -89,5 +95,156 @@ class ReadOnlyField(Generic[StoredT, VisibleT]):
         return self.get_convert(cast(StoredT, instance.data[self.name]))
 
 
-def is_required_field(o: object) -> TypeIs[RequiredField | ReadOnlyField]:
-    return isinstance(o, RequiredField) or isinstance(o, ReadOnlyField)
+_HasDataT = TypeVar("_HasDataT", bound=HasData)
+
+
+class ReadOnlyMethodField(Generic[_HasDataT, StoredT, VisibleT]):
+    __slots__ = ("get_convert", "name")
+
+    def __init__(self, get_convert: Callable[[_HasDataT, StoredT], VisibleT]) -> None:
+        self.get_convert = get_convert
+        self.name: str = "<not set>"
+
+    def __set_name__(self, owner: type, name: str) -> None:
+        if self.name == "<not set>":
+            self.name = name
+
+    def __get__(self, instance: _HasDataT, owner=None) -> VisibleT:
+        return self.get_convert(instance, cast(StoredT, instance.data[self.name]))
+
+
+class StaticMethodField(Generic[StoredT, VisibleT]):
+    __slots__ = ("set_convert", "get_convert", "name")
+
+    def __init__(self, get_convert: Callable[[StoredT], VisibleT]) -> None:
+        self.get_convert = get_convert
+        self.name: str = "<not set>"
+
+        def set_convert(value: VisibleT) -> StoredT:
+            raise NotImplementedError
+
+        self.set_convert: Callable[[VisibleT], StoredT] = set_convert
+
+    def __set_name__(self, owner: type, name: str) -> None:
+        if self.name == "<not set>":
+            self.name = name
+
+    def __get__(self, instance: _HasDataT, owner=None) -> VisibleT:
+        return self.get_convert(cast(StoredT, instance.data[self.name]))
+
+    def __set__(self, instance: _HasDataT, value: VisibleT) -> None:
+        instance.data[self.name] = self.set_convert(value)
+
+    def setter(self, fn: Callable[[VisibleT], StoredT]) -> None:
+        self.set_convert = fn
+
+
+def read_only_field(
+    fn: Callable[[_HasDataT, StoredT], VisibleT],
+) -> ReadOnlyMethodField[_HasDataT, StoredT, VisibleT]:
+    """Decorate a method as getter for a read only field.
+
+    This works similar to the `property` decorator, but will
+    automatically pass the content of the `.data` dictionary
+    to the decorated method, that matches its name, e.g.,
+    decorating a method `name` will call it with `self.data['name']`.
+    The method will also be bound as an instance method, i.e.,
+    the owning instance will be passed as the first argument.
+
+    Additionally, the name of the decorated method will be registered
+    as a required field for all other purposes.
+
+    :::{admonition} Example
+    ```python
+    from elasticai.creator.ir import IrData, required_field
+
+    class MyData(IrData):
+        def __init__(self, data: dict[str, Attribute]):
+            self.data = data
+            self.length_scaling = 2
+
+        @required_field
+        def name(self, value: str) -> str:
+            return value
+
+        @type.setter
+        def _(self, value: str) -> str:
+            return value.lower()
+    ```
+    :::
+    For more information see [`required_field`](#elasticai.creator.ir.required_field).
+    """
+    return ReadOnlyMethodField(fn)
+
+
+def static_required_field(
+    fn: Callable[[StoredT], VisibleT],
+) -> StaticMethodField[StoredT, VisibleT]:
+    """Decorate a static method as getter for a read only field.
+
+    Opposed to `read_only_field` this decorator will not pass the owning instance
+    to the decorated method. This is to avoid hard to catch inconsistencies
+    if the owning instances state changes between read and write operations.
+
+    The main purpose of this decorator is to providea a more readable alternative
+    to [`RequiredField`](#elasticai.creator.ir.required_field.RequiredField).
+
+    :::{note}
+    Type checkers will not be able to pickup that the decorated methods are static by means of our
+    custom descriptor. That means you will probably have to decorate the method with `@staticmethod`
+    before applying `@static_required_field`.
+    :::
+
+    :::{admonition} Example
+    ```python
+    from elasticai.creator.ir import IrData, static_required_field
+
+    class MyData(IrData):
+        @static_required_field
+        @staticmethod
+        def length(value: int) -> float:
+            return value * 2.0
+
+        @length.setter
+        @staticmethod
+        def _(value: float) -> int:
+            return int(value / 2.0)
+    :::
+
+    See also [`read_only_field`](#elasticai.creator.ir.required_field.read_only_field).
+    """
+    return StaticMethodField(fn)
+
+
+_required_fields = [
+    RequiredField,
+    ReadOnlyField,
+    SimpleRequiredField,
+    StaticMethodField,
+    ReadOnlyMethodField,
+]
+
+
+def is_required_field(
+    o: object,
+) -> TypeIs[RequiredField | ReadOnlyField | SimpleRequiredField]:
+    def _isinstance(t):
+        return isinstance(o, t)
+
+    return any(map(_isinstance, _required_fields))
+
+
+def is_required_field_type(
+    cls: type,
+) -> TypeIs[type[RequiredField] | type[ReadOnlyField] | type[RequiredField]]:
+    def _issubclass(t):
+        return isinstance(cls, t)
+
+    return any(map(_issubclass, _required_fields))
+
+
+def register_required_field_type(
+    cls: type,
+) -> None:
+    if cls not in _required_fields:
+        _required_fields.append(cls)


### PR DESCRIPTION
Introduces decorators to define instance methods
as required fields. The advantage is two-fold:

1. The method's type annotations are used to infer the types of the resulting descriptor. This should often be more intuitive than the somewhat lengthy type annotations that were necessary previously.
2. get_convert functions can now access the owning instances state.

For now, we specifically disallow accessing the instances state from writeable field converters as the chance for inconsistencies seems to be too high.