### PR TITLE
feat(ir2torch): support loading model state dicts

### DIFF
--- a/elasticai/creator/ir2torch/ir2torch.py
+++ b/elasticai/creator/ir2torch/ir2torch.py
@@ -1,4 +1,5 @@
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
+from typing import Any
 
 import torch.nn as nn
 from torch import fx
@@ -18,21 +19,39 @@ class Ir2Torch:
             KeyedFunctionDispatcher(key_fn)
         )
 
-    def convert(self, ir: dict[str, Implementation]) -> nn.Module:
+    def convert(
+        self, ir: Iterator[Implementation], state_dict: dict[str, Any] | None = None
+    ) -> nn.Module:
+        """Rebuild the original pytorch model from a given IR.
+
+        :param: `ir`: You need to make sure that `Ir2Torch` has a type handler for each implementation in `ir`
+        :param: `state_dict`: You can optionally pass a state dict. This should be a state dict created
+            from the original model via `nn.Module.state_dict`. As the `Torch2Ir` stage got rid of all
+            duplicate submodules, we will strip all unknown keys from the `state_dict` and then load it.
+        """
         root = nn.Module()
-        for impl in ir.values():
-            if impl.name != "root":
+        _ir = dict((impl.name, impl) for impl in ir)
+        for impl in _ir.values():
+            if impl.name != "":
                 root.add_module(impl.name, self._handle_type(impl))
 
         graph = fx.Graph()
-        ir_root = ir["root"]
+        ir_root = _ir[""]
         for ir_node in ir_root.nodes.values():
             if ir_node.type not in ("input", "output"):
                 graph.call_module(
                     ir_node.implementation, tuple(ir_root.predecessors(ir_node))
                 )
+        module = fx.GraphModule(root, graph)
 
-        return fx.GraphModule(root, graph)
+        if state_dict is not None:
+            filtered_state_dict = {}
+            for key, value in state_dict.items():
+                submodule = ".".join(key.split(".")[:-1])
+                if submodule in _ir:
+                    filtered_state_dict[key] = value
+            module.load_state_dict(filtered_state_dict)
+        return module
 
     def register_type_handlers(
         self, handlers: Iterable[Callable[[Implementation], nn.Module]]

--- a/tests/integration_tests/plugin_integ_test.py
+++ b/tests/integration_tests/plugin_integ_test.py
@@ -71,7 +71,6 @@ def test_can_load_entire_plugin(
     )
     lowerable = make_lowerable(["some", "important", "information"])
     loader.load_from_package("tests.integration_tests.minimal_plugin")
-    print(lower.__dict__["_fns"].__dict__["_fns"])
 
     assert ("some_important_information",) == tuple(lower((lowerable,)))
 

--- a/tests/unit_tests/ir2torch_test.py
+++ b/tests/unit_tests/ir2torch_test.py
@@ -17,23 +17,32 @@ def convert(model):
     return Torch2Ir.get_default_converter().convert(model)
 
 
+def to_native_python(data) -> dict:
+    result = {}
+    for name, p in data:
+        result[name] = p.tolist() if hasattr(p, "tolist") else p
+    return result
+
+
 @given(st.tuples(st.integers(1, 10), st.integers(1, 10)), st.booleans())
 def test_build_model_from_ir_and_state_dict(num_features, bias):
     in_features, out_features = num_features
     original = Sequential(Linear(in_features, out_features, bias))
     ir = convert(original)
     state = original.state_dict()
-    print(ir)
-    rebuilt = Ir2Torch.get_default_converter().convert(ir)
-    print(rebuilt)
-    rebuilt.load_state_dict(state)
+    rebuilt = Ir2Torch.get_default_converter().convert(ir, state)
 
-    def to_native_python(data) -> dict:
-        result = {}
-        for name, p in data:
-            result[name] = p.tolist() if hasattr(p, "tolist") else p
-        return result
+    original_params = to_native_python(original.named_parameters())
+    rebuilt_params = to_native_python(rebuilt.named_parameters())
+    assert original_params == rebuilt_params
 
+
+def test_can_rebuild_model_with_duplicate_submodule():
+    lin = Linear(1, 1)
+    original = Sequential(lin, lin)
+    state = original.state_dict()
+    ir = convert(original)
+    rebuilt = Ir2Torch.get_default_converter().convert(ir, state)
     original_params = to_native_python(original.named_parameters())
     rebuilt_params = to_native_python(rebuilt.named_parameters())
     assert original_params == rebuilt_params

--- a/tests/unit_tests/torch2ir_test.py
+++ b/tests/unit_tests/torch2ir_test.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 import torch
 from torch.nn import Linear, ReLU, Sequential
 
@@ -13,7 +15,7 @@ def model():
 
 def convert(model):
     ir = Torch2Ir.get_default_converter().convert(model)
-    return {impl.name: impl.data for impl in ir.values()}
+    return [impl.as_dict() for impl in ir]
 
 
 def test_convert_linear_without_bias():
@@ -21,42 +23,42 @@ def test_convert_linear_without_bias():
     with torch.no_grad():
         m.get_submodule("0").weight.mul_(0).add_(1)
     ir = convert(m)
-    assert ir == {
-        "root": {
-            "name": "root",
+    assert ir == [
+        {
+            "name": "",
             "type": "module",
-            "nodes": {
-                "input_1": {
+            "nodes": [
+                {
                     "name": "input_1",
                     "type": "input",
                     "implementation": "input",
                 },
-                "_0": {
+                {
                     "name": "_0",
                     "type": "linear",
                     "implementation": "0",
                 },
-                "output": {
+                {
                     "name": "output",
                     "type": "output",
                     "implementation": "output",
                 },
-            },
-            "edges": {
-                ("input_1", "_0"): {"src": "input_1", "sink": "_0"},
-                ("_0", "output"): {"src": "_0", "sink": "output"},
-            },
+            ],
+            "edges": [
+                {"src": "input_1", "sink": "_0"},
+                {"src": "_0", "sink": "output"},
+            ],
         },
-        "0": {
+        {
             "name": "0",
             "type": "linear",
             "in_features": 1,
             "out_features": 2,
             "bias": False,
-            "edges": {},
-            "nodes": {},
+            "edges": [],
+            "nodes": [],
         },
-    }
+    ]
 
 
 def test_convert_linear_to_ir():
@@ -66,54 +68,54 @@ def test_convert_linear_to_ir():
         linear.bias.mul_(0)
         linear.weight.mul_(0).add_(1)
 
-    assert convert(m) == {
-        "0": {
-            "type": "linear",
-            "in_features": 1,
-            "out_features": 2,
-            "bias": True,
-            "edges": {},
-            "name": "0",
-            "nodes": {},
-        },
-        "1": {
-            "type": "relu",
-            "name": "1",
-            "edges": {},
-            "nodes": {},
-        },
-        "root": {
-            "name": "root",
+    assert convert(m) == [
+        {
+            "name": "",
             "type": "module",
-            "nodes": {
-                "input_1": {
+            "nodes": [
+                {
                     "implementation": "input",
                     "name": "input_1",
                     "type": "input",
                 },
-                "_0": {
+                {
                     "name": "_0",
                     "implementation": "0",
                     "type": "linear",
                 },
-                "_1": {
+                {
                     "implementation": "1",
                     "name": "_1",
                     "type": "relu",
                 },
-                "output": {
+                {
                     "implementation": "output",
                     "name": "output",
                     "type": "output",
                 },
-            },
-            "edges": {
-                ("input_1", "_0"): {"src": "input_1", "sink": "_0"},
-                ("_0", "_1"): {"src": "_0", "sink": "_1"},
-                ("_1", "output"): {"src": "_1", "sink": "output"},
-            },
+            ],
+            "edges": [
+                {"src": "input_1", "sink": "_0"},
+                {"src": "_0", "sink": "_1"},
+                {"src": "_1", "sink": "output"},
+            ],
         },
-    }
+        {
+            "type": "linear",
+            "in_features": 1,
+            "out_features": 2,
+            "bias": True,
+            "edges": [],
+            "name": "0",
+            "nodes": [],
+        },
+        {
+            "type": "relu",
+            "name": "1",
+            "edges": [],
+            "nodes": [],
+        },
+    ]
 
 
 def test_converting_model_with_batchnorm():
@@ -127,59 +129,107 @@ def test_converting_model_with_batchnorm():
             return self.relu(self.bn(x))
 
     m = Model()
-    assert convert(m) == {
-        "bn": {
-            "affine": True,
-            "edges": {},
-            "name": "bn",
-            "nodes": {},
-            "num_features": 2,
-            "type": "batchnorm1d",
-        },
-        "relu": {
-            "edges": {},
-            "name": "relu",
-            "nodes": {},
-            "type": "relu",
-        },
-        "root": {
-            "edges": {
-                ("bn", "relu"): {
-                    "sink": "relu",
-                    "src": "bn",
-                },
-                ("relu", "output"): {
-                    "sink": "output",
-                    "src": "relu",
-                },
-                ("x", "bn"): {
+    assert convert(m) == [
+        {
+            "edges": [
+                {
                     "sink": "bn",
                     "src": "x",
                 },
-            },
-            "name": "root",
-            "nodes": {
-                "bn": {
-                    "implementation": "bn",
-                    "name": "bn",
-                    "type": "batchnorm1d",
+                {
+                    "sink": "relu",
+                    "src": "bn",
                 },
-                "output": {
-                    "implementation": "output",
-                    "name": "output",
-                    "type": "output",
+                {
+                    "sink": "output",
+                    "src": "relu",
                 },
-                "relu": {
-                    "implementation": "relu",
-                    "name": "relu",
-                    "type": "relu",
-                },
-                "x": {
+            ],
+            "name": "",
+            "nodes": [
+                {
                     "implementation": "input",
                     "name": "x",
                     "type": "input",
                 },
-            },
+                {
+                    "implementation": "bn",
+                    "name": "bn",
+                    "type": "batchnorm1d",
+                },
+                {
+                    "implementation": "relu",
+                    "name": "relu",
+                    "type": "relu",
+                },
+                {
+                    "implementation": "output",
+                    "name": "output",
+                    "type": "output",
+                },
+            ],
             "type": "module",
         },
-    }
+        {
+            "name": "bn",
+            "type": "batchnorm1d",
+            "edges": [],
+            "nodes": [],
+            "num_features": 2,
+            "affine": True,
+        },
+        {
+            "edges": [],
+            "name": "relu",
+            "nodes": [],
+            "type": "relu",
+        },
+    ]
+
+
+def test_can_handle_same_object_under_different_hierarchy_paths():
+    lin = Linear(1, 1)
+    model = Sequential(OrderedDict(a=lin, b=lin))
+    print(model)
+    assert convert(model) == [
+        {
+            "name": "",
+            "type": "module",
+            "nodes": [
+                {
+                    "name": "input_1",
+                    "type": "input",
+                    "implementation": "input",
+                },
+                {
+                    "name": "a",
+                    "type": "linear",
+                    "implementation": "a",
+                },
+                {
+                    "name": "a_1",
+                    "type": "linear",
+                    "implementation": "a",
+                },
+                {
+                    "name": "output",
+                    "type": "output",
+                    "implementation": "output",
+                },
+            ],
+            "edges": [
+                {"src": "input_1", "sink": "a"},
+                {"src": "a", "sink": "a_1"},
+                {"src": "a_1", "sink": "output"},
+            ],
+        },
+        {
+            "name": "a",
+            "type": "linear",
+            "in_features": 1,
+            "out_features": 1,
+            "bias": True,
+            "edges": [],
+            "nodes": [],
+        },
+    ]


### PR DESCRIPTION
Pytorch tracing will eliminate duplicate submodules and replace them by a single unique object.
When trying to load state dicts generated from
modules with duplicate submodules, that would lead to errors where the values referring to duplicates will miss a corresponding submodule in the result
of the ir2torch conversion.

This commit introduces a feature that will strip
the state dict of all keys not present in an
implementation registry before loading the
state dict. Thus avoiding the problem mentioned
above.