### PR TITLE
feat(ir): support pattern based graph rewriting

### DIFF
--- a/elasticai/creator/ir/__init__.py
+++ b/elasticai/creator/ir/__init__.py
@@ -16,10 +16,12 @@ __all__ = [
     "StaticMethodField",
     "ReadOnlyField",
     "find_subgraphs",
+    "GraphRewriter",
 ]
 from .attribute import Attribute
 from .core import Edge, Node, edge, node
 from .graph import Graph
+from .graph_rewriting import GraphRewriter
 from .ir_data import IrData
 from .ir_data_meta import IrDataMeta
 from .lowering import Lowerable, LoweringPass

--- a/elasticai/creator/ir/graph.py
+++ b/elasticai/creator/ir/graph.py
@@ -1,7 +1,7 @@
 import copy
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from functools import singledispatchmethod
-from typing import Any, Generic, ParamSpec, Self, TypeVar, Union, overload
+from typing import Any, Generic, ParamSpec, Self, TypeVar, Union, cast, overload
 
 from .attribute import Attribute
 from .core import Edge, Node
@@ -223,8 +223,10 @@ class Graph(IrData, Generic[N, E], create_init=False):
 
     def as_dict(self) -> dict[str, Attribute]:
         data = self.data.copy()
-        data["nodes"] = list(n.data for n in self.nodes.values())
-        data["edges"] = list(e.data for e in self.edges.values())
+        data["nodes"] = cast(
+            Attribute, list(n.data for n in self.nodes.values())
+        )  # seems like mypy can't handle the nested recursive type hint list[dict[str, Attribute]]
+        data["edges"] = cast(Attribute, list(e.data for e in self.edges.values()))
         return data
 
     @classmethod

--- a/elasticai/creator/ir/graph.py
+++ b/elasticai/creator/ir/graph.py
@@ -1,5 +1,7 @@
+import copy
 from collections.abc import Callable, Iterable, Iterator, Mapping
-from typing import Any, Generic, ParamSpec, TypeVar, Union, overload
+from functools import singledispatchmethod
+from typing import Any, Generic, ParamSpec, Self, TypeVar, Union, overload
 
 from .attribute import Attribute
 from .core import Edge, Node
@@ -91,21 +93,81 @@ class Graph(IrData, Generic[N, E], create_init=False):
         self._node_fn = node_fn
         self._edge_fn = edge_fn
 
-    def add_node(self, n: N) -> None:
-        self._g.add_node(n.name)
-        self._node_data[n.name] = n.data
+    @overload
+    def add_node(self, n: N) -> Self: ...
 
-    def add_nodes(self, ns: Iterable[N]) -> None:
+    @overload
+    def add_node(self, n: Node) -> Self: ...
+
+    @overload
+    def add_node(self, n: dict[str, Attribute]) -> Self: ...
+
+    @overload
+    def add_node(self, *, name: str, type: str, **attributes: Attribute) -> Self: ...
+
+    @singledispatchmethod  # type: ignore[operator, misc]
+    def add_node(self, *args, **kwargs) -> Self:
+        raise NotImplementedError()
+
+    @add_node.register  # type: ignore[attr-defined]
+    def _(self, n: Node) -> Self:
+        self.add_node(n.data)
+        return self
+
+    @add_node.register  # type: ignore[attr-defined]
+    def _(self, n: dict) -> Self:
+        self._g.add_node(n["name"])
+        self._node_data[n["name"]] = n
+        return self
+
+    @add_node.register  # type: ignore[attr-defined]
+    def _(self, *, name: str, type: str, **attributes: Attribute) -> Self:
+        n = {"name": name, "type": type, **attributes}
+        self.add_node(n)
+        return self
+
+    @overload
+    def add_edge(self, e: E) -> Self: ...
+
+    @overload
+    def add_edge(self, e: Edge) -> Self: ...
+
+    @overload
+    def add_edge(self, e: dict) -> Self: ...
+
+    @overload
+    def add_edge(self, *, src: str, sink: str, **attributes: Attribute) -> Self: ...
+
+    @singledispatchmethod  # type: ignore[operator, misc]
+    def add_edge(self, *args, **kwargs) -> Self:
+        raise NotImplementedError()
+
+    @add_edge.register  # type: ignore[attr-defined]
+    def _(self, e: Edge) -> Self:
+        self.add_edge(e.data)
+        return self
+
+    @add_edge.register  # type: ignore[attr-defined]
+    def _(self, e: dict) -> Self:
+        self._g.add_edge(e["src"], e["sink"])
+        self._edge_data[(e["src"], e["sink"])] = e
+        return self
+
+    @add_edge.register  # type: ignore[attr-defined]
+    def _(self, *, src: str, sink: str, **attributes: Attribute) -> Self:
+        e = {"src": src, "sink": sink, **attributes}
+        self.add_edge(e)
+        return self
+
+    def add_nodes(self, ns: Iterable[N | Node | dict[str, Attribute]]) -> Self:
         for n in ns:
             self.add_node(n)
+        return self
 
-    def add_edges(self, es: Iterable[E]) -> None:
+    def add_edges(self, es: Iterable[E | Edge | dict[str, Attribute]]) -> Self:
         for e in es:
             self.add_edge(e)
-
-    def add_edge(self, e: E) -> None:
-        self._g.add_edge(e.src, e.sink)
-        self._edge_data[(e.src, e.sink)] = e.data
+        return self
 
     def successors(self, node: str | N) -> Mapping[str, N]:
         if not isinstance(node, str):
@@ -161,8 +223,8 @@ class Graph(IrData, Generic[N, E], create_init=False):
 
     def as_dict(self) -> dict[str, Attribute]:
         data = self.data.copy()
-        data["nodes"] = list(self._node_data.values())
-        data["edges"] = list(self._edge_data.values())
+        data["nodes"] = list(n.data for n in self.nodes.values())
+        data["edges"] = list(e.data for e in self.edges.values())
         return data
 
     @classmethod
@@ -209,8 +271,26 @@ class Graph(IrData, Generic[N, E], create_init=False):
         for an already existing graph, e.g., because you want to reuse
         the set `node_fn`, `edge_fn` functions for constructing
         nodes and edges.
+
+        :::{note}
+        `data` is not copied, so it is shared between the original and the new graph.
+        :::
         """
         self.data = data
+
+    def get_empty_copy(self) -> "Graph[N, E]":
+        """Get an empty version of the graph, with the same node_fn and edge_fn.
+
+        This is the complement of `load_dict`.
+
+        :::{note}
+        `node_fn` and `edge_fn` are deep copied, so they are not shared between the
+        original and the new graph.
+        :::
+        """
+        return self.__class__(
+            node_fn=copy.deepcopy(self._node_fn), edge_fn=copy.deepcopy(self._edge_fn)
+        )
 
 
 _K = TypeVar("_K")

--- a/elasticai/creator/ir/graph_rewriting.py
+++ b/elasticai/creator/ir/graph_rewriting.py
@@ -1,0 +1,154 @@
+import copy
+from collections.abc import Callable, Sequence
+from typing import Generic, TypeVar
+
+from .core import Edge, Node
+from .graph import Graph
+from .name_generation import NameRegistry
+
+EdgeT = TypeVar("EdgeT", bound=Edge)
+
+PNodeT = TypeVar("PNodeT", bound=Node)
+INodeT = TypeVar("INodeT", bound=Node)
+RNodeT = TypeVar("RNodeT", bound=Node)
+GNodeT = TypeVar("GNodeT", bound=Node)
+
+
+class GraphRewriter(Generic[PNodeT, INodeT, RNodeT, GNodeT, EdgeT]):
+    """Rewrite graphs based on a pattern, interface, and replacement.
+
+    :param: `pattern`: The pattern to match in the graph.
+    :param: `interface`: The interface where graph and replacement will be "glued" together.
+    :param: `replacement`: The replacement for the pattern.
+    :param: `match`: A function that takes a graph and a pattern and returns a dictionary of matches. See [`find_subgraphs`](#elasticai.creator.ir.find_subgraphs) for more information.
+    :param: `lhs`: A function that is used to map the interface to the pattern.
+    :param: `rhs`: A function that is used to map the interface to the replacement.
+
+    The terminology here is based on the double pushout approach to graph rewriting.
+    The algorithm will find the first occurence of pattern in the graph using the `match` function.
+    Then, it will create a new graph by replacing the pattern with the replacement.
+    The structures specified by `interface` are excluded from this replacement.
+    Instead the interface is used as the "glue" between the original graph and the replacement.
+    The functions `lhs` and `rhs` are used to identify the `interface` nodes in the `pattern` and `replacement` respectively.
+
+    :::{important}
+    * The `rhs` function is required to be injective. This means that each interface node should be mapped to a unique replacement node.
+    * The algorithm will stop on the first match. If you need to replace multiple matches you have to call the `rewrite` function multiple times.
+    * The nodes from `replacement` will be automatically renamed to avoid conflicts with the nodes in the original graph, i.e., if node `a` exists already we will add a new node `a_1`.
+    :::
+
+
+
+    """
+
+    def __init__(
+        self,
+        pattern: Graph[PNodeT, EdgeT],
+        interface: Graph[INodeT, EdgeT],
+        replacement: Graph[RNodeT, EdgeT],
+        match: Callable[
+            [Graph[GNodeT, EdgeT], Graph[PNodeT, EdgeT]], Sequence[dict[str, str]]
+        ],
+        lhs: Callable[[str], str],
+        rhs: Callable[[str], str],
+    ) -> None:
+        self._pattern = pattern
+        self._interface = interface
+        self._replacement = replacement
+        self._match = match
+        self._lhs = lhs
+        self._rhs = rhs
+        self._rhs_inversed = {self._rhs(node): node for node in self._interface.nodes}
+        self._interface_nodes_in_replacement = set(self._rhs_inversed.keys())
+        if len(self._interface.nodes) != len(self._interface_nodes_in_replacement):
+            raise ValueError(
+                "Ensure the `rhs` function is injective. The `rhs` function should map each interface node to a unique replacement node."
+            )
+
+    def rewrite(self, graph: Graph[GNodeT, EdgeT]) -> Graph[GNodeT, EdgeT]:
+        matches = self._match(graph, self._pattern)
+        if len(matches) > 0:
+            match = matches[0]
+        else:
+            return copy.deepcopy(graph)
+        interface_nodes_in_pattern = set(
+            self._lhs(node) for node in self._interface.nodes
+        )
+        interface_nodes_in_graph = set(
+            match[node] for node in interface_nodes_in_pattern
+        )
+
+        new_graph = graph.get_empty_copy()
+        nodes_to_be_removed = set(match.values()) - set(interface_nodes_in_graph)
+        nodes_to_keep = set(graph.nodes.keys()) - nodes_to_be_removed
+        name_registry = SingleNewNameGenerator(
+            NameRegistry().prepopulate(nodes_to_keep)
+        )
+
+        def get_name_for_replacement_node_in_new_graph(node: str) -> str:
+            if node in self._interface_nodes_in_replacement:
+                return match[self._lhs(self._rhs_inversed[node])]
+            if node in nodes_to_keep:
+                return name_registry.get_name(node)
+            return node
+
+        def get_name_for_old_node_in_new_graph(node: str) -> str:
+            return node
+
+        def get_old_node_for_new_graph(node: str) -> Node:
+            node_data = copy.deepcopy(graph.nodes[node].data)
+            node_data["name"] = get_name_for_old_node_in_new_graph(node)
+            return Node(node_data)
+
+        def get_replacement_node_for_new_graph(node: str) -> Node:
+            node_data = copy.deepcopy(self._replacement.nodes[node].data)
+            node_data["name"] = get_name_for_replacement_node_in_new_graph(node)
+            return Node(node_data)
+
+        def get_old_edge_for_new_graph(src: str, sink: str) -> Edge:
+            old_edge = graph.edges[(src, sink)]
+            edge_data = copy.deepcopy(old_edge.data)
+            edge_data["src"] = get_name_for_old_node_in_new_graph(old_edge.src)
+            edge_data["sink"] = get_name_for_old_node_in_new_graph(old_edge.sink)
+            return Edge(edge_data)
+
+        def get_replacement_edge_for_new_graph(src: str, sink: str) -> Edge:
+            replacement_edge = self._replacement.edges[(src, sink)]
+            edge_data = copy.deepcopy(replacement_edge.data)
+            edge_data["src"] = get_name_for_replacement_node_in_new_graph(
+                replacement_edge.src
+            )
+            edge_data["sink"] = get_name_for_replacement_node_in_new_graph(
+                replacement_edge.sink
+            )
+            return Edge(edge_data)
+
+        for node in nodes_to_keep:
+            new_graph.add_node(get_old_node_for_new_graph(node))
+
+        for node in self._replacement.nodes:
+            if node not in self._interface_nodes_in_replacement:
+                new_graph.add_node(get_replacement_node_for_new_graph(node))
+
+        for src, sink in graph.edges:
+            if src in nodes_to_keep and sink in nodes_to_keep:
+                new_graph.add_edge(get_old_edge_for_new_graph(src, sink))
+
+        for src, sink in self._replacement.edges:
+            new_graph.add_edge(get_replacement_edge_for_new_graph(src, sink))
+        return new_graph
+
+
+class SingleNewNameGenerator:
+    def __init__(self, registry: NameRegistry) -> None:
+        self._registry = registry
+        self._reversed: dict[str, str] = {}
+        self._memory: dict[str, str] = {}
+
+    def get_name(self, name: str) -> str:
+        if name in self._memory:
+            return self._memory[name]
+        new_name = self._registry.get_unique_name(name)
+        self._memory[name] = new_name
+        self._reversed[new_name] = name
+        return new_name

--- a/elasticai/creator/ir/name_generation.py
+++ b/elasticai/creator/ir/name_generation.py
@@ -1,0 +1,26 @@
+import re
+
+
+class NameRegistry:
+    def __init__(self):
+        self._registry = {}
+
+    def prepopulate(self, names):
+        for name in names:
+            match = re.match(r"(.+)_(\d+)$", name)
+            if match:
+                name = match.group(1)
+                suffix = int(match.group(2))
+            else:
+                suffix = 0
+            self._registry[name] = self._registry.get(name, suffix) + 1
+        return self
+
+    def get_unique_name(self, name):
+        if name not in self._registry:
+            self._registry[name] = 0
+            return name
+
+        new_name = f"{name}_{self._registry[name]}"
+        self._registry[name] += 1
+        return new_name

--- a/tests/unit_tests/ir/graph_transforms/rewrite_test.py
+++ b/tests/unit_tests/ir/graph_transforms/rewrite_test.py
@@ -1,0 +1,132 @@
+import pytest
+
+from elasticai.creator.ir import GraphRewriter
+
+from .utils import build_graph_from_dict, find_matches
+
+
+def test_can_replace_single_node():
+    graph = build_graph_from_dict(
+        {("a", "a_t"): ["b"], ("b", "b_t"): ["c"], ("c", "c_t"): []}
+    )
+    pattern = build_graph_from_dict(
+        {("0", "a_t"): ["1"], ("1", "b_t"): ["2"], ("2", "c_t"): []}
+    )
+    interface = build_graph_from_dict({("i0", ""): [], ("i1", ""): []})
+    replacement = build_graph_from_dict(
+        {("r0", "a_t"): ["r1"], ("r1", "r_t"): ["r2"], ("r2", "c_t"): []}
+    )
+
+    def lhs(node: str) -> str:
+        return {"i0": "0", "i1": "2"}[node]
+
+    def rhs(node: str) -> str:
+        return {"i0": "r0", "i1": "r2"}[node]
+
+    rewriter = GraphRewriter(pattern, interface, replacement, find_matches, lhs, rhs)
+
+    expected = build_graph_from_dict(
+        {
+            ("c", "c_t"): [],
+            ("a", "a_t"): ["r1"],
+            ("r1", "r_t"): ["c"],
+        }
+    )
+    assert rewriter.rewrite(graph).as_dict() == expected.as_dict()
+
+
+def test_create_new_name_for_replacement_in_case_of_conflict():
+    graph = build_graph_from_dict(
+        {("a", "a_t"): ["b"], ("b", "b_t"): ["c"], ("c", "c_t"): []}
+    )
+    pattern = build_graph_from_dict(
+        {("0", "a_t"): ["1"], ("1", "b_t"): ["2"], ("2", "c_t"): []}
+    )
+    interface = build_graph_from_dict({("i0", ""): [], ("i1", ""): []})
+    replacement = build_graph_from_dict(
+        {("r0", "a_t"): ["a"], ("a", "r_t"): ["r2"], ("r2", "c_t"): []}
+    )
+
+    def lhs(node: str) -> str:
+        return {"i0": "0", "i1": "2"}[node]
+
+    def rhs(node: str) -> str:
+        return {"i0": "r0", "i1": "r2"}[node]
+
+    rewriter = GraphRewriter(pattern, interface, replacement, find_matches, lhs, rhs)
+
+    expected = build_graph_from_dict(
+        {
+            ("c", "c_t"): [],
+            ("a", "a_t"): ["a_1"],
+            ("a_1", "r_t"): ["c"],
+        }
+    )
+    assert rewriter.rewrite(graph).as_dict() == expected.as_dict()
+
+
+def test_raise_error_if_rhs_is_not_injective():
+    pattern = build_graph_from_dict(
+        {("0", "a_t"): ["1"], ("1", "b_t"): ["2"], ("2", "c_t"): []}
+    )
+    interface = build_graph_from_dict({("i0", ""): [], ("i1", ""): []})
+    replacement = build_graph_from_dict(
+        {("r0", "a_t"): ["a"], ("a", "r_t"): ["r2"], ("r2", "c_t"): []}
+    )
+
+    def lhs(node: str) -> str:
+        return {"i0": "0", "i1": "2"}[node]
+
+    def rhs(node: str) -> str:
+        return {"i0": "r0", "i1": "r0"}[node]
+
+    pytest.raises(
+        ValueError,
+        GraphRewriter,
+        pattern,
+        interface,
+        replacement,
+        find_matches,
+        lhs,
+        rhs,
+    )
+
+
+def test_can_replace_one_of_two_matches():
+    graph = build_graph_from_dict(
+        {
+            ("a", "a_t"): ["b"],
+            ("b", "b_t"): ["c"],
+            ("c", "a_t"): ["d"],
+            ("d", "b_t"): ["e"],
+            ("e", "a_t"): [],
+        }
+    )
+    pattern = build_graph_from_dict(
+        {("0", "a_t"): ["1"], ("1", "b_t"): ["2"], ("2", "a_t"): []}
+    )
+    interface = build_graph_from_dict({("i0", ""): [], ("i1", ""): []})
+    replacement = build_graph_from_dict(
+        {("r0", "a_t"): ["r1"], ("r1", "r_t"): ["r2"], ("r2", "c_t"): []}
+    )
+
+    def lhs(node: str) -> str:
+        return {"i0": "0", "i1": "2"}[node]
+
+    def rhs(node: str) -> str:
+        return {"i0": "r0", "i1": "r2"}[node]
+
+    rewriter = GraphRewriter(pattern, interface, replacement, find_matches, lhs, rhs)
+
+    expected = build_graph_from_dict(
+        {
+            ("c", "a_t"): ["r1"],
+            ("a", "a_t"): ["b"],
+            ("b", "b_t"): ["c"],
+            ("r1", "r_t"): ["e"],
+            ("e", "a_t"): [],
+        }
+    )
+    actual = rewriter.rewrite(graph)
+    assert set(actual.edges) == set(expected.edges)
+    assert set(actual.nodes) == set(expected.nodes)

--- a/tests/unit_tests/ir/graph_transforms/subgraph_matching_test.py
+++ b/tests/unit_tests/ir/graph_transforms/subgraph_matching_test.py
@@ -1,4 +1,4 @@
-from elasticai.creator import ir
+from .utils import build_graph_from_dict, find_matches
 
 """
 Test List:
@@ -9,24 +9,6 @@ Test List:
    them to be removed from the next list of potential matches.
 
 """
-
-
-def build_graph_from_dict(d: dict[tuple[str, str], list[str]]) -> ir.Graph:
-    g = ir.Graph()
-    for (node, node_type), successors in d.items():
-        g.add_node(ir.node(node, node_type))
-        for s in successors:
-            g.add_edge(ir.edge(node, s))
-
-    return g
-
-
-def equal_type(a: ir.Node, b: ir.Node) -> bool:
-    return a.type == b.type
-
-
-def find_matches(graph: ir.Graph, pattern: ir.Graph) -> list[dict[str, str]]:
-    return ir.find_subgraphs(graph, pattern, equal_type)
 
 
 def test_find_identical_graph_with_single_node():

--- a/tests/unit_tests/ir/graph_transforms/utils.py
+++ b/tests/unit_tests/ir/graph_transforms/utils.py
@@ -1,0 +1,19 @@
+from elasticai.creator import ir
+
+
+def build_graph_from_dict(d: dict[tuple[str, str], list[str]]) -> ir.Graph:
+    g = ir.Graph()
+    for (node, node_type), successors in d.items():
+        g.add_node(ir.node(node, node_type))
+        for s in successors:
+            g.add_edge(ir.edge(node, s))
+
+    return g
+
+
+def equal_type(a: ir.Node, b: ir.Node) -> bool:
+    return a.type == b.type
+
+
+def find_matches(graph: ir.Graph, pattern: ir.Graph) -> list[dict[str, str]]:
+    return ir.find_subgraphs(graph, pattern, equal_type)

--- a/tests/unit_tests/ir/name_generation_test.py
+++ b/tests/unit_tests/ir/name_generation_test.py
@@ -1,0 +1,32 @@
+from elasticai.creator.ir.name_generation import NameRegistry
+
+
+def test_can_generate_unique_name():
+    reg = NameRegistry()
+    reg.prepopulate(["a", "b", "c"])
+    assert reg.get_unique_name("a") == "a_1"
+    assert reg.get_unique_name("a") == "a_2"
+
+
+def test_name_is_not_altered_if_already_unique():
+    reg = NameRegistry()
+    reg.prepopulate(["a", "b", "c"])
+    assert reg.get_unique_name("d") == "d"
+
+
+def test_prepopulated_suffixes_are_counted():
+    reg = NameRegistry()
+    reg.prepopulate(["a", "a_1", "a_2"])
+    assert reg.get_unique_name("a") == "a_3"
+
+
+def test_start_counting_from_highest_suffix():
+    reg = NameRegistry()
+    reg.prepopulate(["a_3"])
+    assert reg.get_unique_name("a") == "a_4"
+
+
+def test_count_either_no_suffix_or_zero_as_one():
+    reg = NameRegistry()
+    reg.prepopulate(["a", "a_0"])
+    assert reg.get_unique_name("a") == "a_2"


### PR DESCRIPTION
Adds an algorithm loosely based on double push out method for graph rewriting.
This `GraphRewriter` allows to replace the first
found occurence of a given pattern in a graph
by a replacement pattern.

It will perform automatic renaming in case of
naming collisions.