### PR TITLE
chore(pyproject): add wavedrom sphinx extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,8 @@ extensions = [
     "sphinxext.opengraph",
     "sphinxcontrib.plantuml",
     "sphinxcontrib.mermaid",
-    # "sphinxcontrib.wavedrom",  # TODO: make wavedrom work to render waveforms
+    # "sphinxcontrib.kroki",
+    "sphinxcontrib.wavedrom",  # TODO: make wavedrom work to render waveforms
 ]
 
 templates_path = ["_templates"]
@@ -64,7 +65,7 @@ myst_enable_extensions = [
 ]
 
 # allow mermaid usage like on github in markdown
-myst_fence_as_directive = ["mermaid"]
+myst_fence_as_directive = ["mermaid", "wavedrom"]
 
 running_in_autobuild = os.getenv("SPHINX_AUTOBUILD", "NO") == "YES"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ docs = [
     "linkify-it-py>=2.0.3",
     "sphinx-autodoc2>=0.5.0",
     "sphinxext-opengraph>=0.9.1",
+    "sphinxcontrib-kroki>=1.3.0",
 ]
 release = ["git-cliff>=2.7.0"]
 testing = [
@@ -77,6 +78,7 @@ default-groups = ["utils", "testing", "lint", "dev", "docs"]
 
 [tool.uv.sources]
 elasticai-runtime-env5 = { git = "https://github.com/es-ude/elastic-ai.runtime.enV5.git", rev = "a9bc18749b1c1666828453a47c9c37f6f0aa2d61" }
+sphinxcontrib-wavedrom = { git = "https://github.com/glencoe/sphinx-wavedrom.git", rev = "hotfix_html_only_version" }
 
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -468,6 +468,7 @@ docs = [
     { name = "sphinx-autodoc2" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-prompt" },
+    { name = "sphinxcontrib-kroki" },
     { name = "sphinxcontrib-mermaid" },
     { name = "sphinxcontrib-plantuml" },
     { name = "sphinxcontrib-wavedrom" },
@@ -527,9 +528,10 @@ docs = [
     { name = "sphinx-autodoc2", specifier = ">=0.5.0" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-prompt", specifier = ">=1.9.0" },
+    { name = "sphinxcontrib-kroki", specifier = ">=1.3.0" },
     { name = "sphinxcontrib-mermaid", specifier = ">=1.0.0" },
     { name = "sphinxcontrib-plantuml", specifier = ">=0.30" },
-    { name = "sphinxcontrib-wavedrom", specifier = ">=3.0.4" },
+    { name = "sphinxcontrib-wavedrom", git = "https://github.com/glencoe/sphinx-wavedrom.git?rev=hotfix_html_only_version" },
     { name = "sphinxext-opengraph", specifier = ">=0.9.1" },
 ]
 lint = [
@@ -2118,6 +2120,17 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinxcontrib-kroki"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/45/df35ca9fbe04b1dba8a54b5fb9783c6a93e8df345c18fd40c4554a8936b4/sphinxcontrib-kroki-1.3.0.tar.gz", hash = "sha256:90ce45e1f5822443772d4df8ddf031746101dc1fd5a0a831a1db7e0886c49b6a", size = 7500 }
+
+[[package]]
 name = "sphinxcontrib-mermaid"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2159,17 +2172,13 @@ wheels = [
 
 [[package]]
 name = "sphinxcontrib-wavedrom"
-version = "3.0.4"
-source = { registry = "https://pypi.org/simple" }
+version = "0.1.dev148+g8b315a2"
+source = { git = "https://github.com/glencoe/sphinx-wavedrom.git?rev=hotfix_html_only_version#8b315a2ac01c92c3de24681cb7c0d37e444955e9" }
 dependencies = [
     { name = "cairosvg" },
     { name = "sphinx" },
     { name = "wavedrom" },
     { name = "xcffib" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/b5/c09b6ac2b0ac8455ec65ab73b62aaebd77ca6ac7eaee47730f9a4b67812b/sphinxcontrib-wavedrom-3.0.4.tar.gz", hash = "sha256:d334c7541afd917c0c128e1545316cc5d5f61c8df50f17477cb5070909b0d4aa", size = 209122 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/ec/4d733b2ad6b6b55bda555ed3184d6525de3371426bb522106b217b56b35a/sphinxcontrib_wavedrom-3.0.4-py3-none-any.whl", hash = "sha256:1131126ab00c05984cf5c20c3f164b0200209fff7c8c0ad66dd36b019fc3cb95", size = 10676 },
 ]
 
 [[package]]


### PR DESCRIPTION
This allows to draw more complex diagrams
other than mermaid. In this case it is
added to specifically support drawing
wavedrom diagrams of waveforms.