### PR TITLE
test(vhdl): pass command line args to vunit test facade

### DIFF
--- a/elasticai/creator/ir2vhdl/testing/testing.py
+++ b/elasticai/creator/ir2vhdl/testing/testing.py
@@ -11,7 +11,7 @@ def run_vunit_vhdl_testbenches(deps: list[str], test_dir: Path | str):
         test_dir = Path(test_dir)
     test_dir = test_dir.absolute()
     logger.info("using test_dir {}".format(test_dir))
-    vu = VUnit.from_argv([])
+    vu = VUnit.from_argv()
     vu.add_vhdl_builtins()
     lib = vu.add_library("lib")
     for testbench in test_dir.glob("*_tb.vhd"):


### PR DESCRIPTION
This allows to call specific `run_tbs.py` scripts
with command line args. E.g., to open the wave
form viewer for the test run.
Signed-off-by: Lukas Einhaus <lukas.einhaus@uni-due.de>