### PR TITLE
feat(vhdl-plugins): add lutron implementation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,11 +3,10 @@ name: Build and Release Python Package
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
 
 jobs:
-
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
@@ -62,7 +61,7 @@ jobs:
           name: release-dists
           path: dist/
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v2.1.1
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
           inputs: >-
             ./dist/*.tar.gz ./dist/*.whl

--- a/docs/creator/plugins/index.md
+++ b/docs/creator/plugins/index.md
@@ -8,4 +8,5 @@ shift_register
 sliding_window
 striding_shift_register
 skeleton
+lutron
 ```

--- a/docs/creator/plugins/lutron.md
+++ b/docs/creator/plugins/lutron.md
@@ -1,0 +1,2 @@
+```{include} ../../../elasticai/creator_plugins/lutron/README.md
+```

--- a/elasticai/creator_plugins/lutron/README.md
+++ b/elasticai/creator_plugins/lutron/README.md
@@ -1,0 +1,88 @@
+# Lutron Plugin
+
+The Lutron plugin provides functionality to generate VHDL code for lookup tables (LUTs). It allows you to define truth tables that map input values to output values.
+
+## Overview
+
+Lutron generates a VHDL entity that implements a lookup table with:
+
+- Configurable input and output widths
+- User-defined truth table mappings
+- Complete VHDL implementation using a case statement
+
+The truth table entries are tuples of strings containing binary values. Each string must match the specified input_size/output_size.
+
+## Example
+
+Here's a complete example implementing a 2-bit input to 2-bit output LUT:
+
+```python
+from elasticai.creator.ir2vhdl import Implementation
+from elasticai.creator_plugins.lutron.lutron import lutron
+
+# Define a 2-to-2 bit LUT
+impl = Implementation(
+    name="lut_0",
+    type="lutron",
+    data={
+        "input_size": 2,
+        "output_size": 2,
+        "truth_table": (
+            ("00", "11"),  # When input is 00, output is 11
+            ("01", "10"),  # When input is 01, output is 10
+            ("10", "01"),  # When input is 10, output is 01
+            ("11", "11"),  # When input is 11, output is 11
+        ),
+    },
+)
+
+# Generate VHDL code
+name, vhdl_lines = lutron(impl)
+```
+
+The generated VHDL code will create an entity with:
+
+- A std_logic_vector input port `d_in` of width `input_size`
+- A std_logic_vector output port `d_out` of width `output_size`
+- A case statement that implements the truth table logic
+- Proper handling of undefined input cases
+
+## Loading as a Plugin
+
+The Lutron plugin can be loaded dynamically using elasticai's plugin system. This allows you to use Lutron without directly importing it:
+
+```python
+from elasticai.creator.ir2vhdl import Ir2Vhdl
+from elasticai.creator.ir2vhdl import Implementation
+from elasticai.creator.plugin import PluginLoader
+
+# Initialize the lowering pass and plugin loader
+lowering = Ir2Vhdl()
+plugin_loader = PluginLoader(lowering)
+
+# Load the Lutron plugin
+plugin_loader.load_from_package("lutron")
+
+# Create implementation as before
+impl = Implementation(
+    name="my_lut",
+    type="lutron",
+    data={
+        "input_size": 2,
+        "output_size": 2,
+        "truth_table": (
+            ("00", "11"),
+            ("01", "10"),
+            ("10", "01"),
+            ("11", "11"),
+        ),
+    },
+)
+
+# Generate VHDL using the lowering pass with loaded plugin
+name, vhdl_lines = next(lowering([impl]))
+```
+
+When using the plugin system, Lutron is automatically registered with the lowering pass and can be used by specifying `type="lutron"` in your Implementation object.
+
+

--- a/elasticai/creator_plugins/lutron/__init__.py
+++ b/elasticai/creator_plugins/lutron/__init__.py
@@ -1,0 +1,1 @@
+from .lutron import lutron as lutron

--- a/elasticai/creator_plugins/lutron/language.py
+++ b/elasticai/creator_plugins/lutron/language.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+from typing import Iterator
+
+
+@dataclass
+class Port:
+    inputs: dict[str, str]
+    outputs: dict[str, str]
+
+    def signals(self) -> Iterator[str]:
+        for s, type in self.inputs.items():
+            yield f"signal {s} : in {type}"
+        for s, type in self.outputs.items():
+            yield f"signal {s} : out {type}"
+
+
+class VHDLEntity:
+    def __init__(self, name: str, port: Port, generics: dict[str, str]):
+        self._name = name
+        self._generics = generics
+        self._port = port
+
+    def _generate_generic(self):
+        if len(self._generics) > 0:
+            yield "generic ("
+            generics = tuple(self._generics.items())
+            for generic, type in generics[:-1]:
+                yield f"{generic} : {type};"
+            generic, type = generics[-1]
+            yield f"{generic} : {type}"
+            yield ");"
+
+    def _generate_port(self):
+        yield "port ("
+        signals = tuple(self._port.signals())
+        for signal in signals[:-1]:
+            yield f"{signal};"
+        yield signals[-1]
+        yield ");"
+
+    def _generate_library_clause(self):
+        yield from ("library ieee;", "use ieee.std_logic_1164.all;")
+
+    def generate_entity(self) -> Iterator[str]:
+        yield from self._generate_library_clause()
+        yield f"entity {self._name} is"
+        yield from self._generate_generic()
+        yield from self._generate_port()
+        yield "end entity;"

--- a/elasticai/creator_plugins/lutron/lutron.py
+++ b/elasticai/creator_plugins/lutron/lutron.py
@@ -1,0 +1,46 @@
+from itertools import chain
+from typing import TypeAlias
+
+from elasticai.creator.ir2vhdl import Code, Implementation, type_handler
+
+from .language import Port, VHDLEntity
+
+IOPair: TypeAlias = tuple[tuple[int, ...], tuple[int, ...]]
+
+
+@type_handler
+def lutron(lowered: Implementation) -> Code:
+    def _iter():
+        name: str = lowered.name
+        d_in_width: int = lowered.attributes["input_size"]
+        d_out_width: int = lowered.attributes["output_size"]
+        io_pairs: tuple[IOPair, ...] = lowered.attributes["truth_table"]
+        entity = VHDLEntity(
+            name=name,
+            port=Port(
+                inputs=dict(d_in=logic_vector(d_in_width)),
+                outputs=dict(d_out=logic_vector(d_out_width)),
+            ),
+            generics=dict(),
+        )
+
+        def rtl():
+            yield from [
+                f"architecture rtl of {name} is",
+                "begin",
+                "  process (d_in) is",
+                "  begin",
+                "    case d_in is",
+            ]
+            for _in, out in io_pairs:
+                yield f'      when b"{_in}" => d_out <= b"{out}";'
+            yield "      when others => d_out <= (others => 'X');"
+            yield from ("    end case;", "  end process;", "end architecture;")
+
+        yield from chain(entity.generate_entity(), ("",), rtl())
+
+    return lowered.name, _iter()
+
+
+def logic_vector(width: int | str) -> str:
+    return f"std_logic_vector({width} - 1 downto 0)"

--- a/elasticai/creator_plugins/lutron/meta.toml
+++ b/elasticai/creator_plugins/lutron/meta.toml
@@ -1,0 +1,10 @@
+
+[[plugins]]
+name = 'lutron'
+version = '0.1'
+api_version = '0.1'
+target_runtime = 'vhdl'
+target_platform = ''
+generated = ["lutron"]
+static_files = []
+

--- a/elasticai/creator_plugins/lutron/tests/test_lutron.py
+++ b/elasticai/creator_plugins/lutron/tests/test_lutron.py
@@ -1,0 +1,46 @@
+from elasticai.creator.ir2vhdl import Implementation
+from elasticai.creator_plugins.lutron.lutron import lutron
+
+
+def test_can_generate_vhdl_for_lutron():
+    impl = Implementation(
+        name="lut_0",
+        type="lutron",
+        data={
+            "input_size": 2,
+            "output_size": 2,
+            "truth_table": (
+                ("00", "11"),
+                ("01", "10"),
+                ("10", "01"),
+                ("11", "11"),
+            ),
+        },
+    )
+    _, lines = lutron(impl)
+    vhdl = tuple(map(str.strip, lines))
+    expected = (
+        "library ieee;",
+        "use ieee.std_logic_1164.all;",
+        "entity lut_0 is",
+        "port (",
+        "signal d_in : in std_logic_vector(2 - 1 downto 0);",
+        "signal d_out : out std_logic_vector(2 - 1 downto 0)",
+        ");",
+        "end entity;",
+        "",
+        "architecture rtl of lut_0 is",
+        "begin",
+        "process (d_in) is",
+        "begin",
+        "case d_in is",
+        'when b"00" => d_out <= b"11";',
+        'when b"01" => d_out <= b"10";',
+        'when b"10" => d_out <= b"01";',
+        'when b"11" => d_out <= b"11";',
+        "when others => d_out <= (others => 'X');",
+        "end case;",
+        "end process;",
+        "end architecture;",
+    )
+    assert vhdl == expected

--- a/tach.toml
+++ b/tach.toml
@@ -121,5 +121,9 @@ path = "elasticai.creator_plugins.skeleton"
 depends_on = ["elasticai.creator.plugin", "elasticai.creator.ir2vhdl"]
 
 [[modules ]]
+path = "elasticai.creator_plugins.lutron"
+depends_on = ["elasticai.creator.ir2vhdl"]
+
+[[modules ]]
 path = "<root>"
-depends_on = ["elasticai.creator.nn.fixed_point", "elasticai.creator.vhdl", "elasticai.creator.file_generation", "elasticai.creator.nn"]
+depends_on = ["elasticai.creator.file_generation", "elasticai.creator.nn.fixed_point", "elasticai.creator.nn", "elasticai.creator.vhdl"]


### PR DESCRIPTION
A lutron represents a precomputed LUT-based
neuron. This commit adds a plugin that
will automatically generate the hw design
from a given truth table.