### PR TITLE
feat(vhdl-plugins): add combinatorial components

### DIFF
--- a/docs/creator/plugins/combinatorial.md
+++ b/docs/creator/plugins/combinatorial.md
@@ -1,0 +1,2 @@
+```{include} ../../../elasticai/creator_plugins/combinatorial/README.md
+```

--- a/docs/creator/plugins/index.md
+++ b/docs/creator/plugins/index.md
@@ -9,4 +9,5 @@ sliding_window
 striding_shift_register
 skeleton
 lutron
+combinatorial
 ```

--- a/elasticai/creator/ir2vhdl/ir2vhdl.py
+++ b/elasticai/creator/ir2vhdl/ir2vhdl.py
@@ -174,7 +174,7 @@ def vhdl_node(
 
 
 class Edge(_Edge):
-    src_sink_indices: tuple[tuple[int, int], ...]
+    src_sink_indices: tuple[tuple[int, int] | tuple[str, str], ...]
 
     def __hash__(self) -> int:
         return hash((self.src, self.sink, self.src_sink_indices))

--- a/elasticai/creator_plugins/combinatorial/README.md
+++ b/elasticai/creator_plugins/combinatorial/README.md
@@ -1,0 +1,153 @@
+# Combinatorial Plugin
+
+**Defined `PluginSymbol`s:**
+
+* `clocked_combinatorial`
+* `unclocked_combinatorial`
+
+This plugin generates code for two different hardware designs.
+It implements the `clocked_combinatorial` and `unclocked_combinatorial` types.
+To use these implementations register the functions with
+the same name to an `Ir2Vhdl` lowering pass.
+The `unclocked_combinatorial` combines other `unclocked_combinatorial` designs.
+The `clocked_combinatorial` design supports many other designs.
+All designs supported by `clocked_combinatorial` have the same port interface as the `clocked_combinatorial` or `unclocked_combinatorial` design.
+They differ only in their generic parameters.
+
+The symbols take an `elasticai.creator.ir2vhdl.Implementation` a corresponding implementation.
+
+```{note}
+**Supported node types:**
+* `'shift_register'`
+* `'clocked_combinatorial'`
+* `'sliding_window'`
+* `'unclocked_combinatorial'`
+* `'striding_shift_register'`
+```
+
+```{warning}
+The interfaces here are experimental. They are highly likely to change in future versions. E.g., we are currently planning to extend them to include `ready_in`, `ready_out` signals.
+Those could be used by a downstream component to control data flow.
+```
+
+## Combinatorial
+
+```{note}
+**Terminology:**
+The terms _upstream_ and _downstream_ denote the direction of data flow for the rest of this document.
+The _upstream_ component is the one that sends data to the _downstream_ component.
+```
+
+```{list-table}
+:header-rows: 1
+
+* - Name
+  - Direction
+  - Type
+  - Description
+* - `clk`
+  - **in**
+  - `std_logic`
+  - Clock signal. Will typically connects to the clock signal of the enclosing component.
+* - `valid_in`
+  - **in**
+  - `std_logic`
+  - `'1'` on **rising** edge signals valid input data. Processes data only if `valid_in` is `'1'`. Connect this to the `valid_out` of the upstream component.
+* - `valid_out`
+  - **out**
+  - `std_logic`
+  - Drive `HIGH`/`'1'` on **rising** edge to signal that your component's output data is valid. Connect this to the `valid_in` of the downstream component.
+* - `rst`
+  - **in**
+  - `std_logic`
+  - Asynchronous reset: set to `'1'` to reset the network, set to `'0'` to release the reset and allow processing. Typically connects to the reset signal of the enclosing component.
+* - `d_in`
+  - **in**
+  - `std_logic_vector`
+  - Input data window. Connect this to `d_out` of upstream components.
+* - `d_out`
+  - **out**
+  - `std_logic_vector`
+  - All output data. Connect this to `d_in` of downstream components.
+```
+
+```{warning}
+Please note that we will most likely extend the interface above with two more signals, `ready_in` and `ready_out`, in the future.
+
+| Name | Direction | Type | Description |
+|------|-----------|------|-------------|
+| `ready_out` | **out** | `std_logic` | Drive `HIGH`/`'1'` when your component is ready to accept new input data via `d_in`. Connects to `ready_in` of upstream components. |
+| `ready_in` | **in** | `std_logic` | Connects to `ready_out` downstream components. |
+```
+
+## Unclocked Combinatorial
+
+The `unclocked_combinatorial` design holds no state.
+
+| Name | Type | Description |
+|------|------|-------------|
+| `d_in` | `std_logic_vector` | Input data window |
+| `d_out` | `std_logic_vector` | All output data |
+
+## Usage Examples
+
+### Basic Setup
+
+First, register the plugin implementations with the IR2VHDL converter:
+
+```python
+from elasticai.creator.ir2vhdl import IR2VHDL
+from elasticai.creator_plugins.combinatorial import (
+    clocked_combinatorial,
+    unclocked_combinatorial
+)
+
+# Create the IR2VHDL converter
+converter = IR2VHDL()
+
+# Register the implementations
+converter.register('clocked_combinatorial')(clocked_combinatorial)
+converter.register('unclocked_combinatorial')(unclocked_combinatorial)
+```
+
+### Clocked Combinatorial Example
+
+Here's how to create a simple network using a clocked combinatorial component:
+
+```python
+from elasticai.creator.ir2vhdl import Implementation, Shape, vhdl_node
+
+# Create a network with an 8-bit clocked component
+impl = Implementation(name="my_network")
+impl.add_node(vhdl_node(
+    name="input",
+    type="input",
+    implementation="",
+    input_shape=Shape(8, 1),  # 8-bit input
+    output_shape=Shape(8, 1)
+))
+impl.add_node(vhdl_node(
+    name="my_clocked_component",
+    type="clocked_combinatorial",
+    implementation="clocked_combinatorial",
+    input_shape=Shape(8, 1),
+    output_shape=Shape(8, 1)
+))
+impl.add_node(vhdl_node(
+    name="output",
+    type="output",
+    implementation="",
+    input_shape=Shape(8, 1),
+    output_shape=Shape(8, 1)
+))
+
+# Connect the nodes with indices for port mapping,
+impl.add_edge(edge("input", "my_clocked_component", tuple()))
+impl.add_edge(edge("my_clocked_component", "output", tuple())))
+
+# Convert to VHDL
+vhdl_entity_name, vhdl_code = next(converter([impl]))
+```
+
+The unclocked versions are created exactly the same way.
+Their only difference lies in the generated interfaces and control signals.

--- a/elasticai/creator_plugins/combinatorial/__init__.py
+++ b/elasticai/creator_plugins/combinatorial/__init__.py
@@ -1,0 +1,2 @@
+from .clocked_combinatorial import clocked_combinatorial as clocked_combinatorial
+from .unclocked_combinatorial import unclocked_combinatorial as unclocked_combinatorial

--- a/elasticai/creator_plugins/combinatorial/clocked_combinatorial.py
+++ b/elasticai/creator_plugins/combinatorial/clocked_combinatorial.py
@@ -1,0 +1,90 @@
+from collections.abc import Sequence
+from itertools import chain
+
+from elasticai.creator.ir2vhdl import Implementation, type_handler
+
+from .combinatorial import (
+    build_data_signal_connections_for_combinatorial,
+    build_declarations_for_combinatorial,
+    build_instantiations_for_combinatorial,
+    wrap_in_architecture,
+)
+from .language import Port, VHDLEntity
+
+
+@type_handler
+def clocked_combinatorial(impl: Implementation) -> tuple[str, Sequence[str]]:
+    def _iter():
+        input_size = impl.nodes["input"].input_shape.size()
+        output_size = impl.nodes["output"].output_shape.size()
+        entity = VHDLEntity(
+            name=impl.name,
+            port=Port(
+                inputs=dict(
+                    clk="std_logic",
+                    rst="std_logic",
+                    d_in=f"std_logic_vector({input_size} - 1 downto 0)",
+                    valid_in="std_logic",
+                ),
+                outputs=dict(
+                    d_out=f"std_logic_vector({output_size} - 1 downto 0)",
+                    valid_out="std_logic",
+                ),
+            ),
+            generics=dict(),
+        )
+        yield from entity.generate_entity()
+        yield ""
+        declarations = build_declarations_for_combinatorial(impl)
+        declarations = chain(
+            declarations,
+            (
+                "signal valid_out_input : std_logic := '0';",
+                "signal valid_in_output : std_logic := '0';",
+            ),
+        )
+        definitions = build_data_signal_connections_for_combinatorial(impl)
+        connected_valid_signals = []
+        valid_in_out_pairs = tuple(_get_valid_in_out_pairs(impl).items())
+        connected_valid_signals.extend(("valid_out_input <= valid_in;",))
+        for sink, src in valid_in_out_pairs:
+            connected_valid_signals.append(f"valid_in_{sink} <= valid_out_{src};")
+        connected_valid_signals.append("valid_out <= valid_in_output;")
+        definitions = chain(
+            definitions,
+            connected_valid_signals,
+            ("", ""),
+            build_instantiations_for_combinatorial(impl),
+        )
+
+        definitions = chain(
+            definitions,
+        )
+        yield from wrap_in_architecture(impl.name, declarations, definitions)
+
+    return impl.name, tuple(_iter())
+
+
+def _get_valid_in_out_pairs(impl: Implementation) -> dict[str, str]:
+    def is_clocked(node):
+        return node.type in [
+            "striding_shift_register",
+            "sliding_window",
+            "shift_register",
+        ]
+
+    adjacency: dict[str, str] = {}
+    last_clocked_node = "input"
+    for node in filter(is_clocked, impl.nodes.values()):
+        last_clocked_node = node.name
+        if len(adjacency) == 0:
+            adjacency[node.name] = "input"
+        else:
+            for pred in filter(
+                is_clocked,
+                impl.iterate_bfs_up_from(node.name),
+            ):
+                adjacency[node.name] = pred.name
+                break
+    adjacency["output"] = last_clocked_node
+    return adjacency

--- a/elasticai/creator_plugins/combinatorial/combinatorial.py
+++ b/elasticai/creator_plugins/combinatorial/combinatorial.py
@@ -1,0 +1,55 @@
+from collections.abc import Iterator
+
+from elasticai.creator.ir2vhdl import Implementation
+
+from .vhdl_nodes.node_factory import InstanceFactoryForCombinatorial
+from .wiring import (
+    connect_data_signals,
+)
+
+
+def wrap_node(n):
+    return InstanceFactoryForCombinatorial(n)
+
+
+def build_declarations_for_combinatorial(impl: Implementation) -> Iterator[str]:
+    nodes = tuple(wrap_node(n) for n in impl.nodes.values())
+    signal_defs = (line for n in nodes for line in n.define_signals())
+    yield from signal_defs
+
+
+def build_instantiations_for_combinatorial(impl: Implementation) -> Iterator[str]:
+    nodes = tuple(wrap_node(n) for n in impl.nodes.values())
+    instances = tuple(n for n in nodes if n.name not in ("input", "output"))
+    instantiations = (line for n in instances for line in n.instantiate())
+    yield from instantiations
+
+
+def build_data_signal_connections_for_combinatorial(
+    impl: Implementation,
+) -> Iterator[str]:
+    connections = tuple(
+        (e.src, e.sink, e.src_sink_indices) for e in impl.edges.values()
+    )
+    data_signal_connections = connect_data_signals(connections)
+    yield from data_signal_connections
+
+
+def wrap_in_architecture(name, declarations, definitions):
+    def _indent(line):
+        return f"  {line}"
+
+    yield f"architecture rtl of {name} is"
+    yield from map(_indent, declarations)
+    yield "begin"
+    yield from map(
+        _indent,
+        (
+            "d_in_input <= d_in;",
+            "d_out_input <= d_in_input;",
+            "d_out_output <= d_in_output;",
+            "d_out <= d_out_output;",
+        ),
+    )
+    yield from map(_indent, definitions)
+    yield "end architecture;"

--- a/elasticai/creator_plugins/combinatorial/language.py
+++ b/elasticai/creator_plugins/combinatorial/language.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+from typing import Iterator
+
+
+@dataclass
+class Port:
+    inputs: dict[str, str]
+    outputs: dict[str, str]
+
+    def signals(self) -> Iterator[str]:
+        for s, type in self.inputs.items():
+            yield f"signal {s} : in {type}"
+        for s, type in self.outputs.items():
+            yield f"signal {s} : out {type}"
+
+
+class VHDLEntity:
+    def __init__(self, name: str, port: Port, generics: dict[str, str]):
+        self._name = name
+        self._generics = generics
+        self._port = port
+
+    def _generate_generic(self):
+        if len(self._generics) > 0:
+            yield "generic ("
+            generics = tuple(self._generics.items())
+            for generic, type in generics[:-1]:
+                yield f"{generic} : {type};"
+            generic, type = generics[-1]
+            yield f"{generic} : {type}"
+            yield ");"
+
+    def _generate_port(self):
+        yield "port ("
+        signals = tuple(self._port.signals())
+        for signal in signals[:-1]:
+            yield f"{signal};"
+        yield signals[-1]
+        yield ");"
+
+    def _generate_library_clause(self):
+        yield from ("library ieee;", "use ieee.std_logic_1164.all;")
+
+    def generate_entity(self) -> Iterator[str]:
+        yield from self._generate_library_clause()
+        yield f"entity {self._name} is"
+        yield from self._generate_generic()
+        yield from self._generate_port()
+        yield "end entity;"

--- a/elasticai/creator_plugins/combinatorial/meta.toml
+++ b/elasticai/creator_plugins/combinatorial/meta.toml
@@ -1,0 +1,10 @@
+
+[[plugins]]
+name = 'combinatorial'
+version = '0.1'
+api_version = '0.1'
+target_runtime = 'vhdl'
+target_platform = ''
+generated = ["unclocked_combinatorial", "clocked_combinatorial"]
+static_files = []
+

--- a/elasticai/creator_plugins/combinatorial/tests/shift_register_test.py
+++ b/elasticai/creator_plugins/combinatorial/tests/shift_register_test.py
@@ -1,0 +1,42 @@
+from collections.abc import Iterable
+
+from elasticai.creator.ir2vhdl import Shape
+from elasticai.creator.ir2vhdl import VhdlNode as Node
+from elasticai.creator_plugins.combinatorial.vhdl_nodes import shift_register
+
+
+def extract_code_section(lines: Iterable[str], start: str, end: str):
+    section_is_relevant = False
+    lines = map(str.strip, lines)
+    lines = tuple(lines)
+    for line in lines:
+        if not section_is_relevant and line.startswith(start):
+            section_is_relevant = True
+        elif section_is_relevant and line.startswith(end):
+            section_is_relevant = False
+        elif section_is_relevant:
+            yield line
+
+
+def test_shift_register_converts_depth_and_width_to_correct_generics():
+    conv0_channels = 2
+    conv1_kernel_size = 3
+    conv0_out_shape = Shape(conv0_channels, 1)
+    conv1_in_shape = Shape(conv0_channels, conv1_kernel_size)
+    n = Node(
+        dict(
+            name="sr0",
+            type="shift_register",
+            implementation="",
+            input_shape=conv0_out_shape.to_tuple(),
+            output_shape=conv1_in_shape.to_tuple(),
+        )
+    )
+    sr = shift_register(n)
+    entity = tuple(extract_code_section(sr.instantiate(), start="generic", end=")"))
+    entity = set(line.strip(",") for line in entity)
+    expected = {
+        f"DATA_WIDTH => {conv0_channels}",
+        f"NUM_POINTS => {conv1_in_shape.width}",
+    }
+    assert entity == expected

--- a/elasticai/creator_plugins/combinatorial/tests/striding_shift_register_test.py
+++ b/elasticai/creator_plugins/combinatorial/tests/striding_shift_register_test.py
@@ -1,0 +1,33 @@
+from elasticai.creator.ir2vhdl import Shape, VhdlNode
+from elasticai.creator_plugins.combinatorial.vhdl_nodes.striding_shift_register import (
+    striding_shift_register,
+)
+
+from .shift_register_test import extract_code_section
+
+
+def test_shift_register_converts_depth_and_width_to_correct_generics():
+    conv0_channels = 2
+    conv1_kernel_size = 3
+    conv0_out_shape = Shape(conv0_channels, 1)
+    conv1_in_shape = Shape(conv0_channels, conv1_kernel_size)
+    stride = 2
+    n = VhdlNode(
+        dict(
+            name="sr0",
+            type="shift_register",
+            implementation="",
+            input_shape=conv0_out_shape.to_tuple(),
+            output_shape=conv1_in_shape.to_tuple(),
+            stride=stride,
+        )
+    )
+    sr = striding_shift_register(n)
+    entity = tuple(extract_code_section(sr.instantiate(), start="generic", end=")"))
+    entity = set(line.strip(",") for line in entity)
+    expected = {
+        f"DATA_WIDTH => {conv0_channels}",
+        f"NUM_POINTS => {conv1_in_shape.width}",
+        f"STRIDE => {stride}",
+    }
+    assert entity == expected

--- a/elasticai/creator_plugins/combinatorial/tests/test_vhdl_implementation.py
+++ b/elasticai/creator_plugins/combinatorial/tests/test_vhdl_implementation.py
@@ -1,0 +1,31 @@
+from elasticai.creator_plugins.combinatorial.language import Port, VHDLEntity
+
+
+def test_can_generate_entity():
+    expected = [
+        "library ieee;",
+        "use ieee.std_logic_1164.all;",
+        "entity my_entity is",
+        "generic (",
+        "A : int;",
+        "B : positive",
+        ");",
+        "port (",
+        "signal clk : in std_logic;",
+        "signal y : out std_logic_vector(3 - 1 downto 0)",
+        ");",
+        "end entity;",
+    ]
+
+    impl = VHDLEntity(
+        name="my_entity",
+        port=Port(
+            inputs=dict(
+                clk="std_logic",
+            ),
+            outputs=dict(y="std_logic_vector(3 - 1 downto 0)"),
+        ),
+        generics=dict(A="int", B="positive"),
+    )
+    actual = list(map(str.strip, impl.generate_entity()))
+    assert actual == expected

--- a/elasticai/creator_plugins/combinatorial/tests/test_vhdl_nodes.py
+++ b/elasticai/creator_plugins/combinatorial/tests/test_vhdl_nodes.py
@@ -1,0 +1,178 @@
+import pytest
+
+from elasticai.creator.ir2vhdl import Shape, VhdlNode
+
+from ..vhdl_nodes.node_factory import (
+    InstanceFactoryForCombinatorial,
+)
+
+
+@pytest.fixture(scope="class")
+def node(raw_node):
+    return InstanceFactoryForCombinatorial(raw_node)
+
+
+def new_node(
+    name: str,
+    type: str,
+    implementation: str,
+    input_shape: Shape,
+    output_shape: Shape,
+    attributes: dict | None = None,
+) -> VhdlNode:
+    if attributes is None:
+        attributes = {}
+    n = VhdlNode(
+        dict(name=name, type=type, implementation=implementation, **attributes)
+    )
+    n.input_shape = input_shape
+    n.output_shape = output_shape
+
+    return n
+
+
+class TestStridingShiftRegister:
+    @pytest.fixture(scope="class")
+    def raw_node(self):
+        conv0_channels = 2
+        conv1_kernel_size = 3
+        conv0_out_shape = Shape(conv0_channels, 1)
+        conv1_in_shape = Shape(conv0_channels, conv1_kernel_size)
+        n = new_node(
+            name="a",
+            type="striding_shift_register",
+            implementation="striding_shift_register",
+            input_shape=conv0_out_shape,
+            output_shape=conv1_in_shape,
+        )
+        n.data["stride"] = 2
+        return n
+
+    def test_can_instantiate(self, node, raw_node):
+        """
+        data width is the size of a single time step, which
+        translates to number of channels or depth of the preceding convolution
+
+        num points is the number of time steps for the succeeding which corresponds to
+        the kernel size of the succeeding convolution.
+        """
+        stride = raw_node.attributes["stride"]
+        expected = (
+            "a: entity work.striding_shift_register(rtl)",
+            "generic map (",
+            f"DATA_WIDTH => {raw_node.input_shape.depth},",
+            f"NUM_POINTS => {raw_node.output_shape.width},",
+            f"STRIDE => {stride}",
+            ")",
+            "port map (",
+            "clk => clk,",
+            "rst => rst,",
+            "d_in => d_in_a,",
+            "d_out => d_out_a,",
+            "valid_in => valid_in_a,",
+            "valid_out => valid_out_a",
+            ");",
+        )
+        actual = tuple(line.strip() for line in node.instantiate())
+        assert actual == expected
+
+    def test_can_define_signals(self, node, raw_node):
+        signals = tuple(line for line in node.define_signals())
+        expected = (
+            f"signal d_in_a : std_logic_vector({raw_node.input_shape.size()} - 1 downto 0) := (others => '0');",
+            f"signal d_out_a : std_logic_vector({raw_node.output_shape.size()} - 1 downto 0) := (others => '0');",
+            "signal valid_in_a : std_logic := '0';",
+            "signal valid_out_a : std_logic := '0';",
+        )
+        assert signals == expected
+
+
+class TestShiftRegister:
+    @pytest.fixture(scope="class")
+    def raw_node(self):
+        conv0_channels = 2
+        conv1_kernel_size = 3
+        conv0_out_shape = Shape(conv0_channels, 1)
+        conv1_in_shape = Shape(conv0_channels, conv1_kernel_size)
+        n = new_node(
+            name="a",
+            type="shift_register",
+            implementation="impl",
+            input_shape=conv0_out_shape,
+            output_shape=conv1_in_shape,
+        )
+        return n
+
+    def test_can_instantiate(self, node, raw_node):
+        expected = (
+            "a: entity work.impl(rtl)",
+            "generic map (",
+            f"DATA_WIDTH => {raw_node.input_shape.depth},",
+            f"NUM_POINTS => {raw_node.output_shape.width}",
+            ")",
+            "port map (",
+            "clk => clk,",
+            "rst => rst,",
+            "d_in => d_in_a,",
+            "d_out => d_out_a,",
+            "valid_in => valid_in_a,",
+            "valid_out => valid_out_a",
+            ");",
+        )
+        actual = tuple(line.strip() for line in node.instantiate())
+        assert actual == expected
+
+    def test_can_define_signals(self, node):
+        expected = (
+            "signal d_in_a : std_logic_vector(2 - 1 downto 0) := (others => '0');",
+            "signal d_out_a : std_logic_vector(6 - 1 downto 0) := (others => '0');",
+            "signal valid_in_a : std_logic := '0';",
+            "signal valid_out_a : std_logic := '0';",
+        )
+        signals = tuple(line for line in node.define_signals())
+
+        assert signals == expected
+
+
+class TestSlidingWindow:
+    @pytest.fixture(scope="class")
+    def raw_node(self):
+        return new_node(
+            name="a",
+            type="sliding_window",
+            input_shape=Shape(4),
+            output_shape=Shape(2),
+            implementation="impl",
+            attributes={"stride": 2},
+        )
+
+    def test_can_instantiate(self, node):
+        expected = (
+            "a: entity work.impl(rtl)",
+            "generic map (",
+            "STRIDE => 2,",
+            "INPUT_WIDTH => 4,",
+            "OUTPUT_WIDTH => 2",
+            ")",
+            "port map (",
+            "clk => clk,",
+            "rst => rst,",
+            "d_in => d_in_a,",
+            "d_out => d_out_a,",
+            "valid_in => valid_in_a,",
+            "valid_out => valid_out_a",
+            ");",
+        )
+        actual = tuple(line.strip() for line in node.instantiate())
+        assert actual == expected
+
+    def test_can_define_signals(self, node):
+        expected = (
+            "signal d_in_a : std_logic_vector(4 - 1 downto 0) := (others => '0');",
+            "signal d_out_a : std_logic_vector(2 - 1 downto 0) := (others => '0');",
+            "signal valid_in_a : std_logic := '0';",
+            "signal valid_out_a : std_logic := '0';",
+        )
+        signals = tuple(line for line in node.define_signals())
+
+        assert signals == expected

--- a/elasticai/creator_plugins/combinatorial/tests/wiring_test.py
+++ b/elasticai/creator_plugins/combinatorial/tests/wiring_test.py
@@ -1,0 +1,13 @@
+from elasticai.creator_plugins.combinatorial.wiring import connect_data_signals
+
+
+def test_connecting_explicit_data_signals():
+    edge = ("src", "sink", ((1, 1),))
+    code = tuple(connect_data_signals((edge,)))
+    assert code == ("d_in_sink(1) <= d_out_src(1);",)
+
+
+def test_connecting_data_signals_by_range():
+    edge = ("src", "sink", ("range(0, 12)", "range(1, 13)"))
+    code = tuple(connect_data_signals((edge,)))
+    assert code == ("d_in_sink(12 downto 1) <= d_out_src(11 downto 0);",)

--- a/elasticai/creator_plugins/combinatorial/unclocked_combinatorial.py
+++ b/elasticai/creator_plugins/combinatorial/unclocked_combinatorial.py
@@ -1,0 +1,58 @@
+from collections.abc import Callable, Iterator, Sequence
+from itertools import chain
+
+from elasticai.creator.ir2vhdl import Implementation, type_handler
+
+from .combinatorial import wrap_in_architecture
+from .language import Port, VHDLEntity
+from .vhdl_nodes.node_factory import InstanceFactoryForCombinatorial
+from .wiring import connect_data_signals
+
+
+@type_handler
+def unclocked_combinatorial(impl: Implementation) -> tuple[str, Sequence[str]]:
+    def _generate_entity(name, input_size, output_size):
+        entity = VHDLEntity(
+            name=name,
+            port=Port(
+                inputs=dict(
+                    d_in=f"std_logic_vector({input_size} - 1 downto 0)",
+                ),
+                outputs=dict(
+                    d_out=f"std_logic_vector({output_size} - 1 downto 0)",
+                ),
+            ),
+            generics=dict(),
+        )
+        return entity
+
+    return impl.name, combinatorial(impl, _generate_entity)
+
+
+def combinatorial(
+    impl: Implementation, entity_fn: Callable[[str, int, int], VHDLEntity]
+) -> Iterator[str]:
+    name = impl.name
+    nodes = []
+    for n in impl.nodes.values():
+        nodes.append(InstanceFactoryForCombinatorial(n))
+    nodes = tuple(nodes)
+    instances = tuple(n for n in nodes if n.name not in ("input", "output"))
+    input = impl.nodes["input"]
+    output = impl.nodes["output"]
+
+    connections = tuple(
+        (e.src, e.sink, e.src_sink_indices) for e in impl.edges.values()
+    )
+    signal_defs = (line for n in nodes for line in n.define_signals())
+
+    instantiations = (line for n in instances for line in n.instantiate())
+    data_signal_connections = connect_data_signals(connections)
+    entity = entity_fn(name, input.input_shape.size(), output.output_shape.size())
+
+    yield from entity.generate_entity()
+
+    yield ""
+    declarations = signal_defs
+    implementation = chain(data_signal_connections, instantiations)
+    yield from wrap_in_architecture(name, declarations, implementation)

--- a/elasticai/creator_plugins/combinatorial/vhdl_nodes/__init__.py
+++ b/elasticai/creator_plugins/combinatorial/vhdl_nodes/__init__.py
@@ -1,0 +1,13 @@
+from .clocked_combinatorial import clocked_combinatorial
+from .shift_register import shift_register
+from .sliding_window import sliding_window
+from .striding_shift_register import striding_shift_register
+from .unclocked_combinatorial import unclocked_combinatorial
+
+__all__ = [
+    "clocked_combinatorial",
+    "unclocked_combinatorial",
+    "shift_register",
+    "striding_shift_register",
+    "sliding_window",
+]

--- a/elasticai/creator_plugins/combinatorial/vhdl_nodes/clocked_combinatorial.py
+++ b/elasticai/creator_plugins/combinatorial/vhdl_nodes/clocked_combinatorial.py
@@ -1,0 +1,55 @@
+from typing import Any, Callable
+
+from elasticai.creator.ir2vhdl import (
+    Instance,
+    LogicSignal,
+    LogicVectorSignal,
+    NullDefinedLogicSignal,
+    Signal,
+    VhdlNode,
+)
+
+from .node_factory import (
+    InstanceFactoryForCombinatorial,
+)
+
+
+@InstanceFactoryForCombinatorial.register
+def clocked_combinatorial(node):
+    return ClockedInstance(
+        node, input_width=node.input_shape.size(), output_width=node.output_shape.size()
+    )
+
+
+class ClockedInstance(Instance):
+    _logic_signals_with_default_suffix: tuple[str, ...] = tuple()
+    _vector_signals_with_default_suffix: tuple[tuple[str, int], ...] = tuple()
+
+    def __init__(
+        self,
+        node: VhdlNode,
+        input_width: int,
+        output_width: int,
+        generic_map: dict[str, Any] | Callable[[], dict[str, Any]] = lambda: {},
+    ):
+        if callable(generic_map):
+            generic_map = generic_map()
+        port_map: dict[str, Signal] = dict(
+            clk=NullDefinedLogicSignal("clk"),
+            rst=NullDefinedLogicSignal("rst"),
+            d_in=LogicVectorSignal(name="d_in", width=input_width),
+            d_out=LogicVectorSignal(name="d_out", width=output_width),
+        )
+        for name, width in self._vector_signals_with_default_suffix:
+            port_map[name] = LogicVectorSignal(name, width)
+        for name in self._logic_signals_with_default_suffix:
+            port_map[name] = LogicSignal(name)
+        super().__init__(
+            node,
+            generic_map=node.attributes.get("generic_map", {}) | generic_map,  #  pyright: ignore
+            port_map=port_map,
+        )
+
+
+class _ClockedCombinatorial(ClockedInstance):
+    _logic_signals_with_default_suffix = ("valid_in", "valid_out")

--- a/elasticai/creator_plugins/combinatorial/vhdl_nodes/node_factory.py
+++ b/elasticai/creator_plugins/combinatorial/vhdl_nodes/node_factory.py
@@ -1,0 +1,5 @@
+from elasticai.creator.ir2vhdl import (
+    InstanceFactory,
+)
+
+InstanceFactoryForCombinatorial = InstanceFactory()

--- a/elasticai/creator_plugins/combinatorial/vhdl_nodes/shift_register.py
+++ b/elasticai/creator_plugins/combinatorial/vhdl_nodes/shift_register.py
@@ -1,0 +1,24 @@
+from elasticai.creator.ir2vhdl import Instance, VhdlNode
+
+from .clocked_combinatorial import ClockedInstance
+from .node_factory import InstanceFactoryForCombinatorial
+
+
+@InstanceFactoryForCombinatorial.register
+def shift_register(node: VhdlNode) -> Instance:
+    return ShiftRegister(node)
+
+
+class ShiftRegister(ClockedInstance):
+    _logic_signals_with_default_suffix = ("valid_in", "valid_out")
+
+    def __init__(self, node: VhdlNode):
+        data_width = node.input_shape.size()
+        num_points = node.output_shape.width
+        output_width = node.output_shape.size()
+        super().__init__(
+            node,
+            input_width=data_width,
+            output_width=output_width,
+            generic_map={"data_width": data_width, "num_points": num_points},
+        )

--- a/elasticai/creator_plugins/combinatorial/vhdl_nodes/sliding_window.py
+++ b/elasticai/creator_plugins/combinatorial/vhdl_nodes/sliding_window.py
@@ -1,0 +1,37 @@
+from elasticai.creator.ir2vhdl import VhdlNode
+
+from .clocked_combinatorial import ClockedInstance
+from .node_factory import InstanceFactoryForCombinatorial
+
+
+@InstanceFactoryForCombinatorial.register
+def sliding_window(node):
+    return SlidingWindowNode(node)
+
+
+class SlidingWindowNode(ClockedInstance):
+    _logic_signals_with_default_suffix = ("valid_in", "valid_out")
+
+    def __init__(
+        self,
+        node: VhdlNode,
+    ):
+        data_width = node.input_shape.depth
+        num_points = node.output_shape.depth
+        if (
+            "generic_map" in node.attributes  #  pyright: ignore
+            and "stride" in node.attributes["generic_map"]  #  pyright: ignore
+        ):
+            stride = node.attributes["generic_map"]["stride"]  # pyright: ignore
+        else:
+            stride = node.attributes["stride"]  # pyright: ignore
+        super().__init__(
+            node,
+            input_width=data_width,
+            output_width=num_points,
+            generic_map=dict(
+                stride=stride,
+                input_width=data_width,
+                output_width=num_points,
+            ),
+        )

--- a/elasticai/creator_plugins/combinatorial/vhdl_nodes/striding_shift_register.py
+++ b/elasticai/creator_plugins/combinatorial/vhdl_nodes/striding_shift_register.py
@@ -1,0 +1,25 @@
+from elasticai.creator.ir2vhdl import VhdlNode
+
+from .node_factory import InstanceFactoryForCombinatorial
+from .shift_register import ShiftRegister
+
+
+@InstanceFactoryForCombinatorial.register
+def striding_shift_register(node: VhdlNode):
+    return StridingShiftRegister(node)
+
+
+class StridingShiftRegister(ShiftRegister):
+    def __init__(
+        self,
+        node: VhdlNode,
+    ):
+        super().__init__(node)
+        if (
+            "generic_map" in node.attributes  # pyright: ignore
+            and "stride" in node.attributes["generic_map"]  # pyright: ignore
+        ):
+            stride = node.attributes["generic_map"]["stride"]  # pyright: ignore
+        else:
+            stride = node.attributes["stride"]  # pyright: ignore
+        self._generics["stride"] = stride

--- a/elasticai/creator_plugins/combinatorial/vhdl_nodes/unclocked_combinatorial.py
+++ b/elasticai/creator_plugins/combinatorial/vhdl_nodes/unclocked_combinatorial.py
@@ -1,0 +1,33 @@
+from typing import Any, Callable
+
+from elasticai.creator.ir2vhdl import Instance, LogicVectorSignal, VhdlNode
+
+from .node_factory import (
+    InstanceFactoryForCombinatorial,
+)
+
+
+@InstanceFactoryForCombinatorial.register("output")
+@InstanceFactoryForCombinatorial.register("input")
+@InstanceFactoryForCombinatorial.register("lutron")
+@InstanceFactoryForCombinatorial.register
+def unclocked_combinatorial(node):
+    return UnclockedInstance(node)
+
+
+class UnclockedInstance(Instance):
+    def __init__(
+        self,
+        node: VhdlNode,
+        generic_map: dict[str, Any] | Callable[[], dict[str, Any]] = lambda: {},
+    ):
+        if callable(generic_map):
+            generic_map = generic_map()
+        super().__init__(
+            node,
+            generic_map=node.attributes.get("generic_map", {}) | generic_map,  # pyright: ignore
+            port_map=dict(
+                d_in=LogicVectorSignal(name="d_in", width=node.input_shape.size()),
+                d_out=LogicVectorSignal(name="d_out", width=node.output_shape.size()),
+            ),
+        )

--- a/elasticai/creator_plugins/combinatorial/vhdl_nodes/vhdl_node_wrapper.py
+++ b/elasticai/creator_plugins/combinatorial/vhdl_nodes/vhdl_node_wrapper.py
@@ -1,0 +1,77 @@
+import dataclasses
+from abc import abstractmethod
+from typing import Any, Iterator, Protocol
+
+
+class Definable(Protocol):
+    @property
+    @abstractmethod
+    def name(self) -> str: ...
+
+    @abstractmethod
+    def define(self) -> Iterator[str]: ...
+
+
+class Node(Protocol):
+    implementation: str
+    name: str
+    type: str
+    input_shape: tuple[int, int]
+    output_shape: tuple[int, int]
+    attributes: dict[str, Any]
+
+
+class VHDLNodeWrapper:
+    def __init__(
+        self,
+        node: Node,
+        generic_map: dict[str, str],
+        port_map: dict[str, Definable],
+    ):
+        self._node = node
+        self._generics: dict[str, str] = {k.lower(): v for k, v in generic_map.items()}
+        self.port_map = port_map
+
+    def add_signal_with_suffix(
+        self, signal: Definable, prefix: str | None = None
+    ) -> None:
+        suffix = self._node.name
+        prefix = signal.name if prefix is None else prefix
+        self.port_map.update(
+            {signal.name: dataclasses.replace(signal, name=f"{prefix}_{suffix}")}
+        )
+
+    @property
+    def name(self) -> str:
+        return self._node.name
+
+    @property
+    def implementation(self) -> str:
+        return self._node.implementation
+
+    def define_signals(self) -> Iterator[str]:
+        for s in self.port_map.values():
+            yield from s.define()
+
+    def generate_entity(self) -> Iterator[str]:
+        yield ""
+
+    def instantiate(self) -> Iterator[str]:
+        yield from (f"{self.name}: entity work.{self.implementation}(rtl) ",)
+        generics = tuple(self._generics.items())
+        if len(generics) > 0:
+            yield "generic map ("
+            for key, value in generics[:-1]:
+                yield f"  {key.upper()} => {value},"
+            for g in generics[-1:]:
+                yield f"  {g[0].upper()} => {g[1]}"
+            yield "  )"
+        port_map = tuple(self.port_map.items())
+        yield "  port map ("
+
+        for k, v in port_map[:-1]:
+            yield f"    {k} => {v},"
+        for k, v in port_map[-1:]:
+            yield f"    {k} => {v}"
+
+        yield "  );"

--- a/elasticai/creator_plugins/combinatorial/wiring.py
+++ b/elasticai/creator_plugins/combinatorial/wiring.py
@@ -1,0 +1,100 @@
+from collections.abc import Callable, Iterable, Sequence
+from typing import Protocol, TypeVar
+
+_T = TypeVar("_T")
+
+
+class Shape(Protocol):
+    width: int
+
+    def size(self) -> int: ...
+
+
+class Node(Protocol):
+    name: str
+    implementation: str
+    input_shape: Shape
+    output_shape: Shape
+
+
+def _for_each_produce_multiple_lines(
+    fn: Callable[[_T], Iterable[str]],
+) -> Callable[[Iterable[_T]], list[str]]:
+    def _wrapped(items: Iterable[_T]) -> list[str]:
+        result: list[str] = list()
+        for item in items:
+            result.extend(fn(item))
+
+        return result
+
+    return _wrapped
+
+
+def _for_each_produce_single_line(
+    fn: Callable[[_T], str],
+) -> Callable[[Iterable[_T]], list[str]]:
+    @_for_each_produce_multiple_lines
+    def _wrapped(item: _T) -> Iterable[str]:
+        yield fn(item)
+
+    return _wrapped
+
+
+@_for_each_produce_multiple_lines
+def connect_data_signals(
+    edge: tuple[str, str, Sequence[tuple[int, int]] | tuple[str, str]],
+):
+    def get_args(r) -> tuple[int] | tuple[int, int]:
+        args = tuple(int(n) for n in r.strip("range(").rstrip(")").split(","))
+        if len(args) not in (1, 2):
+            raise ValueError(f"Invalid range: {r}")
+        return args  # pyright: ignore
+
+    source, sink, wiring = edge
+
+    if len(wiring) >= 1 and isinstance(wiring[0], tuple) and len(wiring[0]) == 2:
+        for i, j in wiring:
+            yield f"d_in_{sink}({j}) <= d_out_{source}({i});"
+        return
+    if len(wiring) == 0:
+        yield f"d_in_{sink} <= d_out_{source};"
+        return
+    elif (
+        len(wiring) == 2
+        and isinstance(wiring[0], str)
+        and isinstance(wiring[1], str)
+        and wiring[0].startswith("range")
+        and wiring[1].startswith("range")
+    ):
+        src_args = get_args(wiring[0])
+        sink_args = get_args(wiring[1])
+        if len(src_args) <= 2 and len(sink_args) <= 2:
+            if len(src_args) == 1:
+                src_args = (0, src_args[0])
+            if len(sink_args) == 1:
+                sink_args = (0, sink_args[0])
+            yield f"d_in_{sink}({sink_args[1] - 1} downto {sink_args[0]}) <= d_out_{source}({src_args[1] - 1} downto {src_args[0]});"
+            return
+        else:
+            wiring = zip(range(*src_args), range(*sink_args))
+    for i, j in wiring:  # pyright: ignore
+        yield f"d_in_{sink}({j}) <= d_out_{source}({i});"
+
+
+def _define_signal_vector(name, length):
+    return f"signal {name}: std_logic_vector({length}-1 downto 0) := (others => '0');"
+
+
+@_for_each_produce_single_line
+def define_input_data_signals(instance):
+    return _define_signal_vector(f"d_in_{instance.name}", instance.input_shape.size())
+
+
+@_for_each_produce_single_line
+def define_output_data_signals(instance: Node):
+    return _define_signal_vector(f"d_out_{instance.name}", instance.output_shape.size())
+
+
+@_for_each_produce_single_line
+def instantiate_bufferless(instance: Node):
+    return f"{instance.name} : entity work.{instance.implementation}(rtl) port map (x => x_{instance.name}, y => y_{instance.name}, enable => enable);"

--- a/tach.toml
+++ b/tach.toml
@@ -125,5 +125,9 @@ path = "elasticai.creator_plugins.lutron"
 depends_on = ["elasticai.creator.ir2vhdl"]
 
 [[modules ]]
+path = "elasticai.creator_plugins.combinatorial"
+depends_on = ["elasticai.creator.ir2vhdl"]
+
+[[modules ]]
 path = "<root>"
-depends_on = ["elasticai.creator.file_generation", "elasticai.creator.nn.fixed_point", "elasticai.creator.nn", "elasticai.creator.vhdl"]
+depends_on = ["elasticai.creator.nn.fixed_point", "elasticai.creator.vhdl", "elasticai.creator.nn", "elasticai.creator.file_generation"]


### PR DESCRIPTION
The plugin allows to automatically combine existing components, that implement one of
two axi like interfaces (clocked/unclocked), based on a given IR graph.



Closes: #416