### PR TITLE
refactor(graph): use mappings instead of functions for lhs/rhs

### DIFF
--- a/tests/unit_tests/graph/rewrite_test.py
+++ b/tests/unit_tests/graph/rewrite_test.py
@@ -15,11 +15,9 @@ def test_can_replace_single_node():
         {("r0", "a_t"): ["r1"], ("r1", "r_t"): ["r2"], ("r2", "c_t"): []}
     )
 
-    def lhs(node: str) -> str:
-        return {"i0": "0", "i1": "2"}[node]
+    lhs = {"i0": "0", "i1": "2"}
 
-    def rhs(node: str) -> str:
-        return {"i0": "r0", "i1": "r2"}[node]
+    rhs = {"i0": "r0", "i1": "r2"}
 
     rewrite = get_rewriter(pattern, interface, replacement, lhs, rhs)
 
@@ -45,11 +43,9 @@ def test_create_new_name_for_replacement_in_case_of_conflict():
         {("r0", "a_t"): ["a"], ("a", "r_t"): ["r2"], ("r2", "c_t"): []}
     )
 
-    def lhs(node: str) -> str:
-        return {"i0": "0", "i1": "2"}[node]
+    lhs = {"i0": "0", "i1": "2"}
 
-    def rhs(node: str) -> str:
-        return {"i0": "r0", "i1": "r2"}[node]
+    rhs = {"i0": "r0", "i1": "r2"}
 
     rewrite = get_rewriter(pattern, interface, replacement, lhs, rhs)
 
@@ -72,11 +68,8 @@ def test_raise_error_if_rhs_is_not_injective():
         {("r0", "a_t"): ["a"], ("a", "r_t"): ["r2"], ("r2", "c_t"): []}
     )
 
-    def lhs(node: str) -> str:
-        return {"i0": "0", "i1": "2"}[node]
-
-    def rhs(node: str) -> str:
-        return {"i0": "r0", "i1": "r0"}[node]
+    lhs = {"i0": "0", "i1": "2"}
+    rhs = {"i0": "r0", "i1": "r0"}
 
     pytest.raises(
         ValueError,
@@ -107,11 +100,8 @@ def test_can_replace_one_of_two_matches():
         {("r0", "a_t"): ["r1"], ("r1", "r_t"): ["r2"], ("r2", "c_t"): []}
     )
 
-    def lhs(node: str) -> str:
-        return {"i0": "0", "i1": "2"}[node]
-
-    def rhs(node: str) -> str:
-        return {"i0": "r0", "i1": "r2"}[node]
+    lhs = {"i0": "0", "i1": "2"}
+    rhs = {"i0": "r0", "i1": "r2"}
 
     rewrite = get_rewriter(pattern, interface, replacement, lhs, rhs)
 

--- a/tests/unit_tests/graph/utils.py
+++ b/tests/unit_tests/graph/utils.py
@@ -26,7 +26,6 @@ def build_graph_from_dict(
 ) -> Graph:
     graph_dict: dict[str, Iterable[str]] = {k[0]: v for k, v in d.items()}
     data_dict = {k[0]: k[1] for k in d}
-    print(graph_dict)
 
     return Graph(g.Graph.from_dict(graph_dict), data=data_dict)
 
@@ -60,8 +59,8 @@ def get_rewriter(
     pattern: Graph,
     interface: Graph,
     replacement: Graph,
-    lhs: Callable[[str], str],
-    rhs: Callable[[str], str],
+    lhs: dict[str, str],
+    rhs: dict[str, str],
 ) -> Callable[[Graph], Graph]:
     match = Matcher(pattern)
 


### PR DESCRIPTION
There is no real advantage to functions over mappings. In many cases we can just pass plain dicts which are easier to construct than functions and mappings allow us to reason about domain and image (keys and values).