### PR TITLE
feat(graph): provide replaced and resulting subgraph from rewriting

### DIFF
--- a/elasticai/creator/graph/__init__.py
+++ b/elasticai/creator/graph/__init__.py
@@ -4,7 +4,7 @@ from .graph_iterators import (
     bfs_iter_up,
     dfs_pre_order,
 )
-from .graph_rewriting import GraphRewriter
+from .graph_rewriting import GraphRewriter, RewriteResult
 from .name_generation import NameRegistry
 from .subgraph_matching import find_subgraphs
 
@@ -16,4 +16,5 @@ __all__ = [
     "bfs_iter_up",
     "dfs_pre_order",
     "NameRegistry",
+    "RewriteResult",
 ]

--- a/elasticai/creator/graph/graph.py
+++ b/elasticai/creator/graph/graph.py
@@ -1,5 +1,5 @@
 import warnings
-from collections.abc import Iterable, Iterator, Set
+from collections.abc import Iterable, Iterator, Mapping, Set
 from typing import Generic, TypeVar
 
 T = TypeVar("T", int, str)
@@ -23,8 +23,16 @@ class Graph(Generic[T]):
         """We keep successor and predecessor nodes just to allow for easier implementation.
         Currently, this implementation is not optimized for performance.
         """
-        self.successors: dict[T, set[T]] = dict()
-        self.predecessors: dict[T, set[T]] = dict()
+        self._successors: dict[T, set[T]] = dict()
+        self._predecessors: dict[T, set[T]] = dict()
+
+    @property
+    def successors(self) -> Mapping[T, set[T]]:
+        return self._successors.keys().mapping
+
+    @property
+    def predecessors(self) -> Mapping[T, set[T]]:
+        return self._predecessors.keys().mapping
 
     @staticmethod
     def from_dict(d: dict[T, Iterable[T]]):
@@ -36,7 +44,7 @@ class Graph(Generic[T]):
         return g
 
     def as_dict(self) -> dict[T, set[T]]:
-        return self.successors.copy()
+        return self._successors.copy()
 
     def add_edge(self, _from: T, _to: T):
         self.add_node(_from)
@@ -47,14 +55,14 @@ class Graph(Generic[T]):
 
     def add_node(self, node: T):
         if node not in self.predecessors:
-            self.predecessors[node] = set()
+            self._predecessors[node] = set()
         if node not in self.successors:
-            self.successors[node] = set()
+            self._successors[node] = set()
         return self
 
     @property
     def nodes(self) -> Set[T]:
-        return self.successors.keys()
+        return self._successors.keys()
 
     def iter_nodes(self) -> Iterator[T]:
         """Iterator over nodes in a fixed but unspecified order."""

--- a/elasticai/creator/graph/graph_rewriting.py
+++ b/elasticai/creator/graph/graph_rewriting.py
@@ -5,15 +5,21 @@ from .graph import Graph
 from .name_generation import NameRegistry
 
 
+class RewriteResult:
+    def __init__(
+        self,
+        *,
+        new_graph: Graph[str],
+        pattern_to_original: dict[str, str],
+        replacement_to_new: dict[str, str],
+    ) -> None:
+        self.new_graph = new_graph
+        self.pattern_to_original = pattern_to_original
+        self.replacement_to_new = replacement_to_new
+
+
 class GraphRewriter:
     """Rewrite graphs based on a pattern, interface, and replacement.
-
-    :param: `pattern`: The pattern to match in the graph.
-    :param: `interface`: The interface where graph and replacement will be "glued" together.
-    :param: `replacement`: The replacement for the pattern.
-    :param: `match`: A function that takes a graph and a pattern and returns a dictionary of matches. See [`find_subgraphs`](#elasticai.creator.ir.find_subgraphs) for more information.
-    :param: `lhs`: A function that is used to map the interface to the pattern.
-    :param: `rhs`: A function that is used to map the interface to the replacement.
 
     The terminology here is based on the double pushout approach to graph rewriting.
     The algorithm will find the first occurence of pattern in the graph using the `match` function.
@@ -28,6 +34,12 @@ class GraphRewriter:
     * The nodes from `replacement` will be automatically renamed to avoid conflicts with the nodes in the original graph, i.e., if node `a` exists already we will add a new node `a_1`.
     :::
 
+    :param pattern: The pattern to match in the graph.
+    :param interface: The interface where graph and replacement will be "glued" together.
+    :param replacement: The replacement for the pattern.
+    :param match: A function that takes a graph and a pattern and returns a dictionary of matches. See [`find_subgraphs`](#elasticai.creator.ir.find_subgraphs) for more information.
+    :param lhs: A dict that is used to map the interface to the pattern.
+    :param rhs: A dict that is used to map the interface to the replacement.
 
 
     """
@@ -54,12 +66,21 @@ class GraphRewriter:
                 "Ensure the `rhs` function is injective. The `rhs` function should map each interface node to a unique replacement node."
             )
 
-    def rewrite(self, graph: Graph[str]) -> Graph[str]:
+    def rewrite(self, graph: Graph[str]) -> RewriteResult:
+        """Rewrite the graph based on the pattern, interface, and replacement.
+
+        Returns a [`RewriteResult`](#elasticai.creator.ir.graph_rewriting.RewriteResult) object containing the new graph and two dicts mapping nodes from `pattern` to the original graph and nodes from `replacement` to the new graph.
+        matches = self._match(graph, self._pattern)
+        """
         matches = self._match(graph, self._pattern)
         if len(matches) > 0:
             match = matches[0]
         else:
-            return copy.deepcopy(graph)
+            return RewriteResult(
+                new_graph=copy.deepcopy(graph),
+                pattern_to_original={},
+                replacement_to_new={},
+            )
         interface_nodes_in_pattern = set(
             self._lhs[node] for node in self._interface.nodes
         )
@@ -74,58 +95,51 @@ class GraphRewriter:
             NameRegistry().prepopulate(nodes_to_keep)
         )
 
-        def get_name_for_replacement_node_in_new_graph(node: str) -> str:
+        def get_replacement_node_in_new_graph(node: str) -> str:
             if node in self._replacement_nodes_in_interface:
                 return match[self._lhs[self._rhs_inversed[node]]]
             if node in nodes_to_keep:
                 return name_registry.get_name(node)
             return node
 
-        def get_name_for_old_node_in_new_graph(node: str) -> str:
-            return node
-
-        def get_old_node_for_new_graph(node: str) -> str:
-            return get_name_for_old_node_in_new_graph(node)
-
-        def get_replacement_node_for_new_graph(node: str) -> str:
-            return get_name_for_replacement_node_in_new_graph(node)
-
-        def get_old_edge_for_new_graph(src: str, sink: str) -> tuple[str, str]:
-            src = get_name_for_old_node_in_new_graph(src)
-            sink = get_name_for_old_node_in_new_graph(sink)
-            return src, sink
-
         def get_replacement_edge_for_new_graph(src: str, sink: str) -> tuple[str, str]:
-            src = get_name_for_replacement_node_in_new_graph(src)
-            sink = get_name_for_replacement_node_in_new_graph(sink)
+            src = get_replacement_node_in_new_graph(src)
+            sink = get_replacement_node_in_new_graph(sink)
             return src, sink
 
         for node in nodes_to_keep:
-            new_graph.add_node(get_old_node_for_new_graph(node))
+            new_graph.add_node(node)
 
         for node in self._replacement.nodes:
             if node not in self._replacement_nodes_in_interface:
-                new_graph.add_node(get_replacement_node_for_new_graph(node))
+                new_graph.add_node(get_replacement_node_in_new_graph(node))
 
         for src, sink in graph.iter_edges():
             if src in nodes_to_keep and sink in nodes_to_keep:
-                new_graph.add_edge(*get_old_edge_for_new_graph(src, sink))
+                new_graph.add_edge(src, sink)
 
         for src, sink in self._replacement.iter_edges():
             new_graph.add_edge(*get_replacement_edge_for_new_graph(src, sink))
-        return new_graph
+
+        return RewriteResult(
+            new_graph=new_graph,
+            pattern_to_original=match,
+            replacement_to_new={
+                r: get_replacement_node_in_new_graph(r) for r in self._replacement.nodes
+            },
+        )
 
 
 class SingleNewNameGenerator:
     def __init__(self, registry: NameRegistry) -> None:
         self._registry = registry
         self._reversed: dict[str, str] = {}
-        self._memory: dict[str, str] = {}
+        self.memory: dict[str, str] = {}
 
     def get_name(self, name: str) -> str:
-        if name in self._memory:
-            return self._memory[name]
+        if name in self.memory:
+            return self.memory[name]
         new_name = self._registry.get_unique_name(name)
-        self._memory[name] = new_name
+        self.memory[name] = new_name
         self._reversed[new_name] = name
         return new_name

--- a/elasticai/creator_plugins/time_multiplexed_sequential/tests/test_lower_fn_with_sliding_window_input.py
+++ b/elasticai/creator_plugins/time_multiplexed_sequential/tests/test_lower_fn_with_sliding_window_input.py
@@ -50,8 +50,7 @@ def test_inserts_striding_shift_register():
         type=type,
         attributes={"generic_map": {"stride": 2}},
     ).data
-    for node in lowered.nodes.values():
-        print(node)
+
     assert lowered.nodes[name].data == expected
 
 

--- a/tests/unit_tests/graph/graph_test.py
+++ b/tests/unit_tests/graph/graph_test.py
@@ -71,6 +71,5 @@ def test_iterating_depth_first_preorder():
     )
 
     actual = tuple(dfs_pre_order(g.get_successors, "0"))
-    print(tuple(g.get_successors("0")))
     expected = ("0", "1", "3", "5", "2", "4", "6")
     assert actual == expected

--- a/tests/unit_tests/graph/rewrite_test.py
+++ b/tests/unit_tests/graph/rewrite_test.py
@@ -1,6 +1,13 @@
 import pytest
 
-from .utils import build_graph_from_dict, get_rewriter
+from elasticai.creator.graph.graph_rewriting import RewriteResult
+from tests.unit_tests.graph.utils import Graph
+
+from .utils import (
+    build_graph_from_dict,
+    get_rewriter,
+    get_rewriter_returning_full_result,
+)
 
 
 def test_can_replace_single_node():
@@ -117,3 +124,85 @@ def test_can_replace_one_of_two_matches():
     actual = rewrite(graph)
     assert set(actual.edges) == set(expected.edges)
     assert set(actual.nodes) == set(expected.nodes)
+
+
+class TestRewriteResult:
+    @pytest.fixture
+    def graph(self):
+        return build_graph_from_dict(
+            {("a", "a_t"): ["b"], ("b", "b_t"): ["c"], ("c", "c_t"): []}
+        )
+
+    @pytest.fixture
+    def pattern(self):
+        return build_graph_from_dict(
+            {("0", "a_t"): ["1"], ("1", "b_t"): ["2"], ("2", "c_t"): []}
+        )
+
+    @pytest.fixture
+    def replacement(self):
+        return build_graph_from_dict(
+            {("r0", "a_t"): ["r1"], ("r1", "r_t"): ["r2"], ("r2", "c_t"): []}
+        )
+
+    @pytest.fixture
+    def rhs_dict(self):
+        return {"i0": "r0", "i1": "r2"}
+
+    @pytest.fixture
+    def result(
+        self,
+        graph: Graph,
+        pattern: Graph,
+        replacement: Graph,
+        rhs_dict: dict[str, str],
+    ):
+        interface = build_graph_from_dict({("i0", ""): [], ("i1", ""): []})
+
+        lhs = {"i0": "0", "i1": "2"}
+
+        rhs = rhs_dict
+
+        rewrite = get_rewriter_returning_full_result(
+            pattern, interface, replacement, lhs, rhs
+        )
+        result = rewrite(graph)
+        return result
+
+    def test_can_map_pattern_back_to_original_graph(self, result: RewriteResult):
+        expected_pattern_to_original = {"0": "a", "1": "b", "2": "c"}
+
+        assert result.pattern_to_original == expected_pattern_to_original
+
+    def test_can_map_replacement_to_new_graph(self, result: RewriteResult):
+        expected_replacement_to_new = {"r0": "a", "r1": "r1", "r2": "c"}
+
+        assert result.replacement_to_new == expected_replacement_to_new
+
+    def test_can_combine_attribute_from_replacement_and_original_graph(
+        self,
+        result: RewriteResult,
+        graph: Graph,
+        pattern: Graph,
+        replacement: Graph,
+        rhs_dict: dict[str, str],
+    ):
+        graph.data = {"a": "1", "b": "2", "c": "3"}
+        replacement.data = {"r0": "100", "r1": "200", "r2": "300"}
+
+        new_graph = Graph(result.new_graph, {})
+
+        for repl_node in replacement.data:
+            new_node = result.replacement_to_new[repl_node]
+            original_node_with_interesting_value = result.pattern_to_original["1"]
+            interesting_value = graph.data[original_node_with_interesting_value]
+            replacement_value = replacement.data[repl_node]
+            not_in_interface = repl_node not in rhs_dict.values()
+            if not_in_interface:
+                new_graph.data[new_node] = str(
+                    int(replacement_value) + int(interesting_value)
+                )
+            else:
+                new_graph.data[new_node] = graph.data[new_node]
+
+        assert new_graph.data == {"a": "1", "r1": "202", "c": "3"}

--- a/tests/unit_tests/graph/utils.py
+++ b/tests/unit_tests/graph/utils.py
@@ -62,6 +62,22 @@ def get_rewriter(
     lhs: dict[str, str],
     rhs: dict[str, str],
 ) -> Callable[[Graph], Graph]:
+    kwargs = locals()
+    _rewrite = get_rewriter_returning_full_result(**kwargs)
+
+    def rewrite(graph: Graph):
+        return Graph(_rewrite(graph).new_graph, {})
+
+    return rewrite
+
+
+def get_rewriter_returning_full_result(
+    pattern: Graph,
+    interface: Graph,
+    replacement: Graph,
+    lhs: Callable[[str], str],
+    rhs: Callable[[str], str],
+) -> Callable[[Graph], g.RewriteResult]:
     match = Matcher(pattern)
 
     rewriter = g.GraphRewriter(
@@ -75,6 +91,6 @@ def get_rewriter(
 
     def rewrite(graph: Graph):
         match.graph = graph
-        return Graph(rewriter.rewrite(graph.wrapped), {})
+        return rewriter.rewrite(graph.wrapped)
 
     return rewrite

--- a/tests/unit_tests/torch2ir_test.py
+++ b/tests/unit_tests/torch2ir_test.py
@@ -190,7 +190,6 @@ def test_converting_model_with_batchnorm():
 def test_can_handle_same_object_under_different_hierarchy_paths():
     lin = Linear(1, 1)
     model = Sequential(OrderedDict(a=lin, b=lin))
-    print(model)
     assert convert(model) == [
         {
             "name": "",


### PR DESCRIPTION
The graph rewriting feature was only the first step in what we need to transform ir implementations.
The graph rewrite will take care of matching
subgraphs to a pattern and replacing them by a
new graph.
Usually though, the metadata in the resulting
replacement subgraph depends on the original
(replaced) subgraph. E.g., you might want
to keep parameters of a convolution, while
changing the parameters of a batchnorm
and removing the activation function.

Therefore the graph rewriter now provides
access to the replaced, the resulting and
the interface subgraphs, such that we can
fill in the parameters after a subgraph
has been replaced. This keeps the code
for adjusting parameters separate from
the graph rewriter itself.