### PR TITLE
refactor(graph): make pattern/graph args kw only

### DIFF
--- a/elasticai/creator/graph/graph_rewriting.py
+++ b/elasticai/creator/graph/graph_rewriting.py
@@ -1,5 +1,6 @@
 import copy
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Protocol
 
 from .graph import Graph
 from .name_generation import NameRegistry
@@ -16,6 +17,12 @@ class RewriteResult:
         self.new_graph = new_graph
         self.pattern_to_original = pattern_to_original
         self.replacement_to_new = replacement_to_new
+
+
+class Matcher(Protocol):
+    def __call__(
+        self, *, pattern: Graph[str], graph: Graph[str]
+    ) -> Sequence[dict[str, str]]: ...
 
 
 class GraphRewriter:
@@ -46,10 +53,11 @@ class GraphRewriter:
 
     def __init__(
         self,
+        *,
         pattern: Graph[str],
         interface: Graph[str],
         replacement: Graph[str],
-        match: Callable[[Graph[str], Graph[str]], Sequence[dict[str, str]]],
+        match: Matcher,
         lhs: Mapping[str, str],
         rhs: Mapping[str, str],
     ) -> None:
@@ -72,7 +80,7 @@ class GraphRewriter:
         Returns a [`RewriteResult`](#elasticai.creator.ir.graph_rewriting.RewriteResult) object containing the new graph and two dicts mapping nodes from `pattern` to the original graph and nodes from `replacement` to the new graph.
         matches = self._match(graph, self._pattern)
         """
-        matches = self._match(graph, self._pattern)
+        matches = self._match(pattern=self._pattern, graph=graph)
         if len(matches) > 0:
             match = matches[0]
         else:

--- a/tests/unit_tests/graph/utils.py
+++ b/tests/unit_tests/graph/utils.py
@@ -31,10 +31,12 @@ def build_graph_from_dict(
 
 
 def find_matches(graph, pattern) -> list[dict[str, str]]:
-    def node_constraint(graph_node, pattern_node):
+    def node_constraint(pattern_node, graph_node):
         return graph.data[graph_node] == pattern.data[pattern_node]
 
-    return g.find_subgraphs(graph.wrapped, pattern.wrapped, node_constraint)
+    return g.find_subgraphs(
+        pattern=pattern.wrapped, graph=graph.wrapped, node_constraint=node_constraint
+    )
 
 
 class Matcher:
@@ -52,7 +54,9 @@ class Matcher:
     def __call__(
         self, graph: g.Graph[str], pattern: g.Graph[str]
     ) -> list[dict[str, str]]:
-        return g.find_subgraphs(graph, pattern, self._node_constraint)
+        return g.find_subgraphs(
+            pattern=pattern, graph=graph, node_constraint=self._node_constraint
+        )
 
 
 def get_rewriter(
@@ -75,8 +79,8 @@ def get_rewriter_returning_full_result(
     pattern: Graph,
     interface: Graph,
     replacement: Graph,
-    lhs: Callable[[str], str],
-    rhs: Callable[[str], str],
+    lhs: dict[str, str],
+    rhs: dict[str, str],
 ) -> Callable[[Graph], g.RewriteResult]:
     match = Matcher(pattern)
 


### PR DESCRIPTION
The arguments tend to be of same type and
making a mistake with their order in find_subgraph or graph rewriting can lead to annoying errors.
Therefore most of the involved functions now
require kw arguments.