### PR TITLE
feat(ir_transform): support reordering of sequential subgraphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .ijwb/
 data
 venv
+.venv
+.tach
 simulation
 simulation/*
 node_modules

--- a/docs/creator/ir.md
+++ b/docs/creator/ir.md
@@ -57,9 +57,9 @@ Edge
 
 Source / Sink
 
-:   Given an edge $(n_1, n_2) \in E_G$ we call $n_1$ **source** and
-    $n_2$ **sink**. The terms refer to the direction of data flow. They
-    have been chosen over other possible terms like input/output because
+:   Given an edge $(n_1, n_2) \in E_G$ we call $n_1$ **source** (`src`) and
+    $n_2$ **sink** (`sink`). The terms refer to the direction of data flow.
+    They have been chosen over other possible terms like input/output because
     those are reserved tokens in many programming languages.
 
 Lowering Pass

--- a/elasticai/creator/graph/__init__.py
+++ b/elasticai/creator/graph/__init__.py
@@ -1,3 +1,4 @@
+from .base_graph import BaseGraph
 from .graph import Graph
 from .graph_iterators import (
     bfs_iter_down,
@@ -9,6 +10,7 @@ from .name_generation import NameRegistry
 from .subgraph_matching import find_subgraphs
 
 __all__ = [
+    "BaseGraph",
     "Graph",
     "find_subgraphs",
     "GraphRewriter",

--- a/elasticai/creator/graph/base_graph.py
+++ b/elasticai/creator/graph/base_graph.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import warnings
+from collections.abc import Iterable, Iterator, Mapping, Set
+from typing import Self
+
+from .graph import Graph
+
+
+# we have to keep this bound to str, until we move to python 3.13 with default type arguments
+class BaseGraph(Graph[str]):
+    """All iterators in this class are guaranteed to have a fixed
+    order. strhat means, the order of iteration is only allowed
+    to change when the data structure is altered. If the
+    content of two GraphDelegates is the same and they were built
+    in the same way, then their iteration order is the same as well.
+
+    :::{caution}
+    This class is not thread-safe.
+    :::
+
+    :::{note}
+    We are not providing methods for removal of nodes or edges on purpose.
+        If you need to remove nodes or edges, you should create a new GraphDelegate.
+        Manipulation of the graph should usually be done in a dedicated build phase.
+    :::
+    """
+
+    def __init__(self) -> None:
+        """We keep successor and predecessor nodes just to allow for easier implementation.
+        Currently, this implementation is not optimized for performance.
+        """
+        self._successors: dict[str, set[str]] = dict()
+        self._predecessors: dict[str, set[str]] = dict()
+
+    @property
+    def successors(self) -> Mapping[str, set[str]]:
+        return self._successors.keys().mapping
+
+    @property
+    def predecessors(self) -> Mapping[str, set[str]]:
+        return self._predecessors.keys().mapping
+
+    @staticmethod
+    def from_dict(d: dict[str, Iterable[str]]):
+        g: Graph[str] = BaseGraph()
+        for node, successors in d.items():
+            g.add_node(node)
+            for s in successors:
+                g.add_edge(node, s)
+        return g
+
+    def as_dict(self) -> dict[str, set[str]]:
+        return self._successors.copy()
+
+    def add_edge(self, _from: str, _to: str) -> Self:
+        self.add_node(_from)
+        self.add_node(_to)
+        self.predecessors[_to].add(_from)
+        self.successors[_from].add(_to)
+        return self
+
+    def add_node(self, node: str) -> Self:
+        if node not in self.predecessors:
+            self._predecessors[node] = set()
+        if node not in self.successors:
+            self._successors[node] = set()
+        return self
+
+    @property
+    def nodes(self) -> Set[str]:
+        return self._successors.keys()
+
+    def iter_nodes(self) -> Iterator[str]:
+        """Iterator over nodes in a fixed but unspecified order."""
+        yield from self.predecessors.keys()
+
+    def iter_edges(self) -> Iterator[tuple[str, str]]:
+        """Iterator over edges in a fixed but unspecified order."""
+        for _from, _tos in self.successors.items():
+            for _to in _tos:
+                yield _from, _to
+
+    def get_edges(self) -> Iterator[tuple[str, str]]:
+        """Iterator over edges in a fixed but unspecified order."""
+        warnings.warn(
+            "get_edges() is deprecated, use iter_edges() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        yield from self.iter_edges()
+
+    def get_successors(self, node: str) -> Iterator[str]:
+        """Iterator over node successors in a fixed but unspecified order."""
+        yield from sorted(self.successors[node])
+
+    def get_predecessors(self, node: str) -> Iterator[str]:
+        """Iterator over node predecessors in a fixed but unspecified order."""
+        yield from sorted(self.predecessors[node])
+
+    def new(self) -> Graph[str]:
+        return BaseGraph()

--- a/elasticai/creator/graph/graph.py
+++ b/elasticai/creator/graph/graph.py
@@ -1,92 +1,31 @@
-import warnings
-from collections.abc import Iterable, Iterator, Mapping, Set
-from typing import Generic, TypeVar
+from abc import abstractmethod
+from collections.abc import Iterator, Mapping, Set
+from typing import Protocol, Self, TypeVar
 
-T = TypeVar("T", int, str)
+T = TypeVar("T", str, int)
 
 
-class Graph(Generic[T]):
-    """All iterators in this class are guaranteed to have a fixed
-    order. That means, the order of iteration is only allowed
-    to change when the data structure is altered. If the
-    content of two GraphDelegates is the same and they were built
-    in the same way, then their iteration order is the same as well.
+class Graph(Protocol[T]):
+    @property
+    @abstractmethod
+    def nodes(self) -> Set[T]: ...
 
-    NOTE: This class is not thread-safe.
+    @abstractmethod
+    def iter_edges(self) -> Iterator[tuple[T, T]]: ...
 
-    NOTE: We are not providing methods for removal of nodes or edges on purpose.
-        If you need to remove nodes or edges, you should create a new GraphDelegate.
-        Manipulation of the graph should usually be done in a dedicated build phase.
-    """
+    @abstractmethod
+    def add_node(self, node: T) -> Self: ...
 
-    def __init__(self) -> None:
-        """We keep successor and predecessor nodes just to allow for easier implementation.
-        Currently, this implementation is not optimized for performance.
-        """
-        self._successors: dict[T, set[T]] = dict()
-        self._predecessors: dict[T, set[T]] = dict()
+    @abstractmethod
+    def add_edge(self, src: T, sink: T) -> Self: ...
 
     @property
-    def successors(self) -> Mapping[T, set[T]]:
-        return self._successors.keys().mapping
+    @abstractmethod
+    def predecessors(self) -> Mapping[T, set[T]]: ...
 
     @property
-    def predecessors(self) -> Mapping[T, set[T]]:
-        return self._predecessors.keys().mapping
+    @abstractmethod
+    def successors(self) -> Mapping[T, set[T]]: ...
 
-    @staticmethod
-    def from_dict(d: dict[T, Iterable[T]]):
-        g: Graph[T] = Graph()
-        for node, successors in d.items():
-            g.add_node(node)
-            for s in successors:
-                g.add_edge(node, s)
-        return g
-
-    def as_dict(self) -> dict[T, set[T]]:
-        return self._successors.copy()
-
-    def add_edge(self, _from: T, _to: T):
-        self.add_node(_from)
-        self.add_node(_to)
-        self.predecessors[_to].add(_from)
-        self.successors[_from].add(_to)
-        return self
-
-    def add_node(self, node: T):
-        if node not in self.predecessors:
-            self._predecessors[node] = set()
-        if node not in self.successors:
-            self._successors[node] = set()
-        return self
-
-    @property
-    def nodes(self) -> Set[T]:
-        return self._successors.keys()
-
-    def iter_nodes(self) -> Iterator[T]:
-        """Iterator over nodes in a fixed but unspecified order."""
-        yield from self.predecessors.keys()
-
-    def iter_edges(self) -> Iterator[tuple[T, T]]:
-        """Iterator over edges in a fixed but unspecified order."""
-        for _from, _tos in self.successors.items():
-            for _to in _tos:
-                yield _from, _to
-
-    def get_edges(self) -> Iterator[tuple[T, T]]:
-        """Iterator over edges in a fixed but unspecified order."""
-        warnings.warn(
-            "get_edges() is deprecated, use iter_edges() instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        yield from self.iter_edges()
-
-    def get_successors(self, node: T) -> Iterator[T]:
-        """Iterator over node successors in a fixed but unspecified order."""
-        yield from sorted(self.successors[node])
-
-    def get_predecessors(self, node: T) -> Iterator[T]:
-        """Iterator over node predecessors in a fixed but unspecified order."""
-        yield from sorted(self.predecessors[node])
+    @abstractmethod
+    def new(self) -> "Graph[T]": ...

--- a/elasticai/creator/graph/graph_rewriting.py
+++ b/elasticai/creator/graph/graph_rewriting.py
@@ -20,9 +20,7 @@ class RewriteResult:
 
 
 class Matcher(Protocol):
-    def __call__(
-        self, *, pattern: Graph[str], graph: Graph[str]
-    ) -> Sequence[dict[str, str]]: ...
+    def __call__(self, *, pattern: Graph, graph: Graph) -> Sequence[dict[str, str]]: ...
 
 
 class GraphRewriter:
@@ -96,7 +94,7 @@ class GraphRewriter:
             match[node] for node in interface_nodes_in_pattern
         )
 
-        new_graph: Graph[str] = Graph()
+        new_graph: Graph = graph.new()
         nodes_to_be_removed = set(match.values()) - set(interface_nodes_in_graph)
         nodes_to_keep = set(graph.nodes) - nodes_to_be_removed
         name_registry = SingleNewNameGenerator(

--- a/elasticai/creator/graph/subgraph_matching.py
+++ b/elasticai/creator/graph/subgraph_matching.py
@@ -2,7 +2,7 @@ from collections.abc import Callable, Iterator
 from functools import singledispatchmethod
 from typing import Generic, Protocol, TypeVar, overload
 
-from .graph import Graph
+from elasticai.creator.graph.graph import Graph
 
 T = TypeVar("T", int, str)
 TPattern = TypeVar("TPattern", int, str)
@@ -317,11 +317,11 @@ class _SubgraphMatcher(Generic[TPattern, T]):
         )
 
     def _pick_a_start_node_from_pattern(self) -> _MatcherNode[TPattern]:
-        return _MatcherNode(next(self._pattern.iter_nodes()), self._pattern)
+        return _MatcherNode(next(iter(self._pattern.nodes)), self._pattern)
 
     def _find_all_start_nodes_from_graph(self, start_node: TPattern) -> set[T]:
         matches = set()
-        for node in self._graph.iter_nodes():
+        for node in self._graph.nodes:
             if self._node_constraint(pattern_node=start_node, graph_node=node):
                 matches.add(node)
         return matches

--- a/elasticai/creator/ir/__init__.py
+++ b/elasticai/creator/ir/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
     "read_only_field",
     "StaticMethodField",
     "ReadOnlyField",
+    "GraphProtocol",
 ]
 from .base import (
     Attribute,
@@ -25,4 +26,15 @@ from .base import (
     read_only_field,
     static_required_field,
 )
-from .core import Edge, Implementation, Lowerable, LoweringPass, Node, edge, node
+from .core import (
+    Edge,
+    Implementation,
+    Lowerable,
+    LoweringPass,
+    Node,
+    edge,
+    node,
+)
+from .core import (
+    Graph as GraphProtocol,
+)

--- a/elasticai/creator/ir/base/ir_data.py
+++ b/elasticai/creator/ir/base/ir_data.py
@@ -11,9 +11,11 @@ class IrData(metaclass=IrDataMeta, create_init=False):
     To create a new Ir data class, inherit from `IrData` and define your required fields.
     Supported field types are
 
-    - xref:elasticai-creator:api:elasticai.creator.ir.required_field.adoc#RequiredField[`RequiredField`]
-    - xref:elasticai-creator:api:elasticai.creator.ir.required_field.adoc#ReadOnlyField[`ReadOnlyField`]
-    - xref:elasticai-creator:api:elasticai.creator.ir.required_field.adoc#SimpleField[`SimpleField`]
+    - ['RequiredField'](#elasticai.creator.ir.required_field.RequiredField)
+    - [`ReadOnlyField`](#elasticai.creator.ir.required_field.ReadOnlyField)
+    - [`SimpleField`](#elasticai.creator.ir.required_field.SimpleField)
+    - [`StaticMethodField`](#elasticai.creator.ir.required_field.static_required_field)
+    - [`ReadOnlyMethodField`](#elasticai.creator.ir.required_field.read_only_field)
 
     Examples:
 

--- a/elasticai/creator/ir/base/ir_data.py
+++ b/elasticai/creator/ir/base/ir_data.py
@@ -61,13 +61,14 @@ class IrData(metaclass=IrDataMeta, create_init=False):
         return missing
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}({self.data})"
+        return f"{self.__module__}.{self.__class__.__qualname__}({self.data})"
 
     def __eq__(self, o: object) -> bool:
         if self is o:
             return True
-        if isinstance(o, self.__class__):
+        if hasattr(o, "data"):
             return o.data == self.data
+
         return False
 
 

--- a/elasticai/creator/ir/core/__init__.py
+++ b/elasticai/creator/ir/core/__init__.py
@@ -1,5 +1,5 @@
 from .core import Edge, Node, edge, node
-from .implementation import Implementation
+from .implementation import Graph, Implementation
 from .lowering import Lowerable, LoweringPass
 
 __all__ = [
@@ -10,4 +10,5 @@ __all__ = [
     "LoweringPass",
     "Lowerable",
     "Implementation",
+    "Graph",
 ]

--- a/elasticai/creator/ir2vhdl/ir2vhdl.py
+++ b/elasticai/creator/ir2vhdl/ir2vhdl.py
@@ -11,7 +11,7 @@ from typing import Any, Iterator, TypeAlias, TypeGuard, TypeVar, overload
 import elasticai.creator.function_utils as F
 import elasticai.creator.plugin as _pl
 from elasticai.creator.function_utils import KeyedFunctionDispatcher
-from elasticai.creator.graph import Graph
+from elasticai.creator.graph import BaseGraph
 from elasticai.creator.ir import (
     Attribute,
     LoweringPass,
@@ -221,7 +221,7 @@ class Implementation(_Implementation[N, E]):
         type: str | None = None,
         data: dict[str, Attribute] | None = None,
         attributes: dict[str, Attribute] | None = None,
-        graph: Graph | None = None,
+        graph: BaseGraph | None = None,
     ) -> None: ...
 
     @overload
@@ -233,7 +233,7 @@ class Implementation(_Implementation[N, E]):
         type: str | None = None,
         data: dict[str, Attribute] | None = None,
         attributes: dict[str, Attribute] | None = None,
-        graph: Graph | None = None,
+        graph: BaseGraph | None = None,
     ) -> None: ...
 
     @overload
@@ -246,7 +246,7 @@ class Implementation(_Implementation[N, E]):
         type: str | None = None,
         data: dict[str, Attribute] | None = None,
         attributes: dict[str, Attribute] | None = None,
-        graph: Graph | None = None,
+        graph: BaseGraph | None = None,
     ) -> None: ...
 
     def __init__(
@@ -258,7 +258,7 @@ class Implementation(_Implementation[N, E]):
         edge_fn=Edge,
         data: dict[str, Any] | None = None,
         attributes: dict[str, Any] | None = None,
-        graph: Graph | None = None,
+        graph: BaseGraph | None = None,
     ) -> None:
         if attributes is not None and data is not None:
             raise TypeError("pass either attributes or data argument")
@@ -276,7 +276,7 @@ class Implementation(_Implementation[N, E]):
         if type is not None:
             data["type"] = type
         if graph is None:
-            graph = Graph()
+            graph = BaseGraph()
         super().__init__(
             node_fn=node_fn,
             edge_fn=edge_fn,

--- a/elasticai/creator/ir_transforms/__init__.py
+++ b/elasticai/creator/ir_transforms/__init__.py
@@ -1,0 +1,3 @@
+from .reorder import NodeConstraint, SequenceReorderer
+
+__all__ = ["SequenceReorderer", "NodeConstraint"]

--- a/elasticai/creator/ir_transforms/reorder.py
+++ b/elasticai/creator/ir_transforms/reorder.py
@@ -1,0 +1,135 @@
+import copy
+from collections.abc import Sequence
+from typing import Protocol, TypeVar, cast
+
+from elasticai.creator import graph as g
+from elasticai.creator import ir
+from elasticai.creator.graph import Graph
+from elasticai.creator.torch2ir import Implementation
+
+
+def build_sequential_pattern(
+    sequence: Sequence[ir.Node],
+) -> ir.Implementation[ir.Node, ir.Edge]:
+    pattern = ir.Implementation(graph=g.BaseGraph())
+    previous = None
+    for node in sequence:
+        pattern.add_node(node)
+        if previous is not None:
+            pattern.add_edge(src=previous, sink=node.name)
+        previous = node.name
+
+    return pattern
+
+
+PNode = TypeVar("PNode", bound=ir.Node)
+GNode = TypeVar("GNode", bound=ir.Node)
+
+PNodeCon = TypeVar("PNodeCon", bound=ir.Node, contravariant=True)
+GNodeCon = TypeVar("GNodeCon", bound=ir.Node, contravariant=True)
+
+
+class NodeConstraint(Protocol[PNodeCon, GNodeCon]):
+    def __call__(self, *, pattern_node: PNodeCon, graph_node: GNodeCon) -> bool: ...
+
+
+class _Matcher:
+    def __init__(
+        self,
+        pattern: ir.Implementation[ir.Node, ir.Edge],
+        graph: ir.Implementation[ir.Node, ir.Edge],
+        node_constraint: NodeConstraint[ir.Node, ir.Node],
+    ):
+        self.pattern = pattern
+        self.graph = graph
+        self._node_constraint = node_constraint
+
+    def set_graph(self, graph: ir.Implementation[ir.Node, ir.Edge]) -> None:
+        self.graph = graph
+
+    def node_constraint(self, pattern_node: str, graph_node: str) -> bool:
+        return self._node_constraint(
+            pattern_node=self.pattern.nodes[pattern_node],
+            graph_node=self.graph.nodes[graph_node],
+        )
+
+    def __call__(self, pattern: Graph[str], graph: Graph[str]) -> list[dict[str, str]]:
+        return g.find_subgraphs(
+            pattern=pattern, graph=graph, node_constraint=self.node_constraint
+        )
+
+
+class SequenceReorderer:
+    def __init__(
+        self,
+        old_order: Sequence[ir.Node],
+        new_order: Sequence[ir.Node],
+        node_constraint: NodeConstraint[ir.Node, ir.Node],
+    ):
+        """Use this to reorder the first occurence of a pattern as specified by the replacement."""
+        pattern = old_order
+        replacement = new_order
+        self.pattern = build_sequential_pattern(pattern)
+        self.replacement = build_sequential_pattern(replacement)
+        self.interface = g.BaseGraph().add_node("start").add_node("end")
+        self.lhs = {"start": pattern[0].name, "end": pattern[-1].name}
+        self.rhs = {"start": replacement[0].name, "end": replacement[-1].name}
+        self.matcher = _Matcher(
+            pattern=self.pattern,
+            graph=Implementation(data={}, graph=g.BaseGraph()),
+            node_constraint=node_constraint,
+        )
+        self._has_changed = False
+
+    def _get_nodes_that_are_in_pattern_and_replacement(self) -> set[str]:
+        return set(self.pattern.nodes) & set(self.replacement.nodes)
+
+    def has_changed(self) -> bool:
+        """Tells whether the graph has been changed by the last call to reorder."""
+        return self._has_changed
+
+    def reorder(self, impl: ir.Implementation) -> ir.Implementation:
+        """Reorder the first occurence of the pattern as specified by the replacement.
+
+        The resulting graph and its data are deep copies of the input graph and its data.
+        The new node names are unique but chosen based on the replacement nodes and
+        not based on the original node names.
+        Use `has_changed` to check whether the graph has been changed by the last call to `reorder`
+        if you want to keep reordering until you reach a fixed point.
+
+        :::{note}
+        Will create a deep copy even if no changes were made.
+        As such it is always safe to `del original_graph` after calling `reorder`.
+        :::
+        """
+        self.matcher.set_graph(impl)
+        rewriter = g.GraphRewriter(
+            pattern=self.pattern.graph,
+            interface=self.interface,
+            replacement=self.replacement.graph,
+            match=self.matcher,
+            lhs=self.lhs,
+            rhs=self.rhs,
+        )
+        result = rewriter.rewrite(impl.graph)
+        self._has_changed = len(result.pattern_to_original) == 0
+
+        new_data = copy.deepcopy(impl.data)
+
+        def copy_original_data_to_replaced_subgraph(
+            pattern_node: str, replacement_node: str
+        ) -> None:
+            new_name = result.replacement_to_new[replacement_node]
+
+            cast(dict[str, ir.Attribute], new_data["nodes"])[new_name] = cast(
+                dict,
+                copy.deepcopy(
+                    cast(dict[str, ir.Attribute], new_data["nodes"])[
+                        cast(str, result.pattern_to_original[pattern_node])
+                    ]
+                ),
+            ) | {"name": new_name}
+
+        for node in self._get_nodes_that_are_in_pattern_and_replacement():
+            copy_original_data_to_replaced_subgraph(node, node)
+        return ir.Implementation(graph=result.new_graph, data=new_data)

--- a/elasticai/creator/torch2ir/core.py
+++ b/elasticai/creator/torch2ir/core.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from elasticai.creator.ir import Edge
+from elasticai.creator.ir import Attribute, Edge, GraphProtocol
 from elasticai.creator.ir import Implementation as _Implementation
 from elasticai.creator.ir import Node as _Node
 from elasticai.creator.ir import node as _node
@@ -31,3 +31,17 @@ def output_node(attributes: dict[str, Any] | None = None) -> Node:
 class Implementation(_Implementation[Node, Edge]):
     name: str
     type: str
+
+    def __init__(
+        self,
+        *,
+        graph: GraphProtocol,
+        name: str | None = None,
+        type: str | None = None,
+        data: dict[str, Attribute] | None = None,
+    ):
+        super().__init__(data=data, graph=graph, node_fn=Node, edge_fn=Edge)
+        if name is not None:
+            self.name = name
+        if type is not None:
+            self.type = type

--- a/elasticai/creator/torch2ir/torch2ir.py
+++ b/elasticai/creator/torch2ir/torch2ir.py
@@ -6,7 +6,7 @@ from torch.fx import Tracer
 from torch.nn import Module
 
 from elasticai.creator.function_utils import KeyedFunctionDispatcher
-from elasticai.creator.graph import Graph
+from elasticai.creator.graph import BaseGraph
 
 from .core import Edge, Implementation, new_node
 from .default_handlers import handlers as default_handlers
@@ -29,7 +29,7 @@ class Torch2Ir:
         super().__init__()
         self._tracer = tracer
         self._registry: dict[str, Implementation] = {}
-        self._root = Implementation(graph=Graph())
+        self._root = Implementation(graph=BaseGraph())
         self._root.type = "module"
         self._root.name = ""
         self._registry[""] = self._root
@@ -114,7 +114,7 @@ class Torch2Ir:
         impl = ir_node.implementation
         if impl not in self._registry and impl not in ("input", "output"):
             self._registry[impl] = Implementation(
-                graph=Graph(),
+                graph=BaseGraph(),
                 data=dict(
                     name=impl, type=ir_node.type, **self._extract_attributes(node)
                 ),

--- a/elasticai/creator/torch2ir/torch2ir.py
+++ b/elasticai/creator/torch2ir/torch2ir.py
@@ -8,7 +8,7 @@ from torch.nn import Module
 from elasticai.creator.function_utils import KeyedFunctionDispatcher
 from elasticai.creator.graph import Graph
 
-from .core import Edge, Implementation, Node, new_node
+from .core import Edge, Implementation, new_node
 from .default_handlers import handlers as default_handlers
 
 
@@ -29,7 +29,7 @@ class Torch2Ir:
         super().__init__()
         self._tracer = tracer
         self._registry: dict[str, Implementation] = {}
-        self._root = Implementation(node_fn=Node, edge_fn=Edge, graph=Graph())
+        self._root = Implementation(graph=Graph())
         self._root.type = "module"
         self._root.name = ""
         self._registry[""] = self._root
@@ -115,8 +115,6 @@ class Torch2Ir:
         if impl not in self._registry and impl not in ("input", "output"):
             self._registry[impl] = Implementation(
                 graph=Graph(),
-                node_fn=Node,
-                edge_fn=Edge,
                 data=dict(
                     name=impl, type=ir_node.type, **self._extract_attributes(node)
                 ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,12 @@ testing = [
 utils = ["rust-just>=1.38.0"]
 versioning = ["towncrier>=24.8.0"]
 lint = ["mypy>=1.13.0", "ruff>=0.9.0"]
-lsp = ["pylsp-mypy>=0.6.9", "pylsp-rope>=0.1.17", "python-lsp-server>=1.12.0"]
+lsp = [
+    "esbonio>=0.16.5",
+    "pylsp-mypy>=0.6.9",
+ "pylsp-rope>=0.1.17",
+ "python-lsp-server>=1.12.0",
+]
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/tach.toml
+++ b/tach.toml
@@ -4,143 +4,189 @@ exclude = [
     "**/docs",
     "**/tests",
     "**/venv",
-    "dist/**/*"
+    "dist/**/*",
 ]
 exact = true
 forbid_circular_dependencies = true
 root_module = "dependenciesonly"
-source_roots = [ "." ]
+source_roots = ["."]
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.ir"
-depends_on = [ "elasticai.creator.function_utils"]
+depends_on = ["elasticai.creator.function_utils", "elasticai.creator.graph"]
 
 [[interfaces]]
-expose = [
-"[a-zA-Z0-9_]+",
-]
+expose = ["[a-zA-Z0-9_]+"]
 from = [
     "elasticai.creator.ir",
     "elasticai.creator.ir2vhdl",
     "elasticai.creator.ir2torch",
     "elasticai.creator.torch2ir",
     "elasticai.creator.graph",
+    "elasticai.creator.ir_transforms",
 ]
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.ir2vhdl"
-depends_on = [ "elasticai.creator.ir", "elasticai.creator.plugin", "elasticai.creator.function_utils", "elasticai.creator.template", "elasticai.creator.graph"]
+depends_on = [
+    "elasticai.creator.ir",
+    "elasticai.creator.plugin",
+    "elasticai.creator.function_utils",
+    "elasticai.creator.template",
+    "elasticai.creator.graph",
+]
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.plugin"
 depends_on = []
 
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.nn"
-depends_on = [ "elasticai.creator.base_modules", "elasticai.creator.nn.sequential", "elasticai.creator.nn.identity"]
+depends_on = [
+    "elasticai.creator.base_modules",
+    "elasticai.creator.nn.sequential",
+    "elasticai.creator.nn.identity",
+]
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.vhdl"
-depends_on = ["elasticai.creator.file_generation", "elasticai.creator.hw_function_id"]
+depends_on = [
+    "elasticai.creator.file_generation",
+    "elasticai.creator.hw_function_id",
+]
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.hw_accelerator_meta"
 depends_on = []
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.function_utils"
 depends_on = []
 
 [[interfaces]]
-expose = [
-    "[a-zA-Z_]*"
-]
+expose = ["[a-zA-Z_]*"]
 from = ["elasticai.creator_plugins.[a-z_]+"]
 
 
-
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.template"
 depends_on = []
 
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.base_modules"
 depends_on = []
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.file_generation"
 depends_on = []
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator_plugins.middleware"
 depends_on = []
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.hw_function_id"
 depends_on = []
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.nn.design_creator_module"
 depends_on = ["elasticai.creator.vhdl"]
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.nn.identity"
-depends_on = ["elasticai.creator.nn.design_creator_module", "elasticai.creator.vhdl", "elasticai.creator.file_generation", "elasticai.creator.base_modules"]
+depends_on = [
+    "elasticai.creator.nn.design_creator_module",
+    "elasticai.creator.vhdl",
+    "elasticai.creator.file_generation",
+    "elasticai.creator.base_modules",
+]
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.nn.quantized_grads"
 depends_on = ["elasticai.creator.base_modules"]
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.nn.fixed_point"
-depends_on = ["elasticai.creator.vhdl", "elasticai.creator.nn.design_creator_module", "elasticai.creator.file_generation", "elasticai.creator.base_modules"]
+depends_on = [
+    "elasticai.creator.vhdl",
+    "elasticai.creator.nn.design_creator_module",
+    "elasticai.creator.file_generation",
+    "elasticai.creator.base_modules",
+]
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.nn.float"
 depends_on = ["elasticai.creator.base_modules"]
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.nn.sequential"
-depends_on = ["elasticai.creator.file_generation", "elasticai.creator.nn.design_creator_module", "elasticai.creator.vhdl"]
+depends_on = [
+    "elasticai.creator.file_generation",
+    "elasticai.creator.nn.design_creator_module",
+    "elasticai.creator.vhdl",
+]
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.ir2vhdl.testing"
 depends_on = []
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.ir2torch"
 depends_on = ["elasticai.creator.torch2ir", "elasticai.creator.ir"]
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.torch2ir"
-depends_on = ["elasticai.creator.ir", "elasticai.creator.function_utils", "elasticai.creator.graph"]
+depends_on = [
+    "elasticai.creator.ir",
+    "elasticai.creator.function_utils",
+    "elasticai.creator.graph",
+]
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator_plugins.skeleton"
 depends_on = ["elasticai.creator.plugin", "elasticai.creator.ir2vhdl"]
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator_plugins.lutron"
 depends_on = ["elasticai.creator.ir2vhdl"]
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator_plugins.combinatorial"
 depends_on = ["elasticai.creator.ir2vhdl"]
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator_plugins.grouped_filter"
-depends_on = ["elasticai.creator.ir2vhdl", "elasticai.creator.function_utils", "elasticai.creator.plugin"]
+depends_on = [
+    "elasticai.creator.ir2vhdl",
+    "elasticai.creator.function_utils",
+    "elasticai.creator.plugin",
+]
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator_plugins.time_multiplexed_sequential"
-depends_on = ["elasticai.creator.function_utils", "elasticai.creator.ir2vhdl", "elasticai.creator.plugin", "elasticai.creator_plugins.grouped_filter", "elasticai.creator.ir", "elasticai.creator.graph"]
+depends_on = [
+    "elasticai.creator.function_utils",
+    "elasticai.creator.ir2vhdl",
+    "elasticai.creator.plugin",
+    "elasticai.creator_plugins.grouped_filter",
+    "elasticai.creator.ir",
+    "elasticai.creator.graph",
+]
 
-[[modules ]]
+[[modules]]
 path = "elasticai.creator.graph"
 depends_on = []
 
-[[modules ]]
+[[modules]]
+path = "elasticai.creator.ir_transforms"
+depends_on = [
+    "elasticai.creator.torch2ir",
+    "elasticai.creator.ir",
+    "elasticai.creator.graph",
+]
+
+[[modules]]
 path = "<root>"
-depends_on = ["elasticai.creator.vhdl", "elasticai.creator.file_generation", "elasticai.creator.nn", "elasticai.creator.nn.fixed_point"]
+depends_on = ["elasticai.creator.file_generation", "elasticai.creator.nn", "elasticai.creator.vhdl", "elasticai.creator.nn.fixed_point"]

--- a/tests/unit_tests/graph/graph_test.py
+++ b/tests/unit_tests/graph/graph_test.py
@@ -1,4 +1,4 @@
-from elasticai.creator.graph import Graph as GraphDelegate
+from elasticai.creator.graph import BaseGraph as GraphDelegate
 from elasticai.creator.graph import bfs_iter_up, dfs_pre_order
 
 

--- a/tests/unit_tests/graph/utils.py
+++ b/tests/unit_tests/graph/utils.py
@@ -27,7 +27,7 @@ def build_graph_from_dict(
     graph_dict: dict[str, Iterable[str]] = {k[0]: v for k, v in d.items()}
     data_dict = {k[0]: k[1] for k in d}
 
-    return Graph(g.Graph.from_dict(graph_dict), data=data_dict)
+    return Graph(g.BaseGraph.from_dict(graph_dict), data=data_dict)
 
 
 def find_matches(graph, pattern) -> list[dict[str, str]]:

--- a/tests/unit_tests/ir/implementation_test.py
+++ b/tests/unit_tests/ir/implementation_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from elasticai.creator.graph import Graph as _Graph
+from elasticai.creator.graph import BaseGraph as _Graph
 from elasticai.creator.ir import Attribute, Edge, Implementation, Node, edge, node
 
 

--- a/tests/unit_tests/ir/ir_data_graph_test.py
+++ b/tests/unit_tests/ir/ir_data_graph_test.py
@@ -1,4 +1,4 @@
-from elasticai.creator.graph import Graph as _Graph
+from elasticai.creator.graph import BaseGraph as _Graph
 from elasticai.creator.ir import Edge, Implementation, Node, edge, node
 from elasticai.creator.ir.base.attribute import Attribute
 

--- a/tests/unit_tests/ir2vhd_test.py
+++ b/tests/unit_tests/ir2vhd_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from pytest import fixture
 
-from elasticai.creator.graph.graph import Graph
+from elasticai.creator.graph.base_graph import BaseGraph
 from elasticai.creator.ir2vhdl import (
     Edge,
     Implementation,
@@ -49,7 +49,7 @@ def test_store_as_dict(data, impl):
 
 
 def test_load_from_dict(data):
-    assert data == Implementation(graph=Graph()).load_from_dict(data).as_dict()
+    assert data == Implementation(graph=BaseGraph()).load_from_dict(data).as_dict()
 
 
 def test_can_access_attributes_of_vhdl_node():

--- a/tests/unit_tests/ir_transforms/reorder_test.py
+++ b/tests/unit_tests/ir_transforms/reorder_test.py
@@ -1,0 +1,225 @@
+from enum import StrEnum
+
+import pytest
+
+import elasticai.creator.ir as ir
+from elasticai.creator.graph import BaseGraph
+from elasticai.creator.ir_transforms import SequenceReorderer
+from elasticai.creator.torch2ir import (
+    Implementation,
+    Node,
+    input_node,
+    new_edge,
+    output_node,
+)
+
+
+def reorder_blocks(impl: Implementation) -> Implementation:
+    N = NodeType
+
+    def make_nodes(*args: tuple[str, NodeType]) -> list[ir.Node]:
+        return [ir.node(name=name, type=type.value) for name, type in args]
+
+    pattern = make_nodes(
+        ("conv", N.CONV1D),
+        ("pool", N.MAXPOOL1D),
+        ("bnorm", N.BATCHNORM1D),
+        ("bin", N.BINARIZE),
+        ("end", N.ANY),
+    )
+
+    replacement = make_nodes(
+        ("conv", N.CONV1D),
+        ("bnorm", N.BATCHNORM1D),
+        ("bin", N.BINARIZE),
+        ("pool", N.MAXPOOL1D),
+        ("end", N.ANY),
+    )
+
+    def constraint(pattern_node: ir.Node, graph_node: ir.Node) -> bool:
+        if pattern_node.type == N.ANY:
+            return True
+        return pattern_node.type == graph_node.type
+
+    reorderer = SequenceReorderer(
+        old_order=pattern,
+        new_order=replacement,
+        node_constraint=constraint,
+    )
+
+    reordered = reorderer.reorder(impl)
+    return Implementation(data=reordered.data, graph=reordered.graph)
+
+
+class NodeType(StrEnum):
+    CONV1D = "conv1d"
+    BATCHNORM1D = "batchnorm1d"
+    MAXPOOL1D = "maxpool1d"
+    BINARIZE = "binarize"
+    ANY = "any"
+
+
+class Conv1d(Node):
+    in_channels: int
+    out_channels: int
+    kernel_size: int
+    bias: bool
+    groups: int
+    stride: int
+    padding: int
+
+    @staticmethod
+    def new(
+        name: str,
+        implementation: str,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        bias: bool,
+        groups: int,
+        stride: int,
+        padding: int,
+    ) -> "Conv1d":
+        args = locals() | {"type": NodeType.CONV1D.value}
+        return Conv1d(args)
+
+
+class Batchnorm1d(Node):
+    num_features: int
+    affine: bool
+
+    @staticmethod
+    def new(
+        name: str, implementation: str, num_features: int, affine: bool
+    ) -> "Batchnorm1d":
+        args = locals() | {"type": NodeType.BATCHNORM1D.value}
+        return Batchnorm1d(args)
+
+
+class Binarize(Node):
+    @staticmethod
+    def new(name: str, implementation: str) -> "Binarize":
+        return Binarize(
+            dict(name=name, type=NodeType.BINARIZE.value, implementation=implementation)
+        )
+
+
+class MaxPool1d(Node):
+    kernel_size: int
+    stride: int
+
+    @staticmethod
+    def new(
+        name: str,
+        implementation: str,
+        kernel_size: int,
+        stride: int,
+    ) -> "MaxPool1d":
+        args = locals() | {"type": NodeType.MAXPOOL1D.value}
+        return MaxPool1d(args)
+
+
+class SequentialBuilder:
+    def __init__(self):
+        self.clear()
+
+    def _save_last_node(self, node: Node):
+        self._last_node = node
+
+    def clear(self) -> "SequentialBuilder":
+        self.ir = Implementation(graph=BaseGraph())
+        self.ir.name = "root"
+        self.ir.type = "module"
+        self._last_node = None
+        return self
+
+    def append(self, *nodes: Node) -> "SequentialBuilder":
+        if len(nodes) > 1:
+            for node in nodes:
+                self.append(node)
+        else:
+            node = nodes[0]
+            if self._last_node is None and node.type != "input":
+                self.append(input_node())
+            self.ir.add_node(node)
+            if self._last_node is not None:
+                self.ir.add_edge(new_edge(self._last_node.name, node.name))
+            self._save_last_node(node)
+        return self
+
+    def build(self) -> Implementation:
+        if self._last_node.type != "output":
+            self.append(output_node())
+        return self.ir
+
+
+class TestReordering:
+    # Note: the node names in the replaced subgraph are dictated by the function under test
+    # We choose the same names for the nodes in the original graph, to make the test shorter
+
+    @pytest.fixture(scope="class")
+    def conv(self):
+        return Conv1d.new(
+            "conv",
+            "conv1",
+            in_channels=3,
+            out_channels=64,
+            kernel_size=3,
+            bias=False,
+            groups=1,
+            stride=1,
+            padding=0,
+        )
+
+    @pytest.fixture(scope="class")
+    def bnorm(self):
+        return Batchnorm1d.new("bnorm", "bn", num_features=64, affine=True)
+
+    @pytest.fixture(scope="class")
+    def pooling(self):
+        return MaxPool1d.new("pool", "maxpool", kernel_size=2, stride=2)
+
+    @pytest.fixture(scope="class")
+    def binarize(self):
+        return Binarize.new("bin", "binarize")
+
+    @pytest.fixture(scope="class")
+    def seq(
+        self, conv: Conv1d, bnorm: Batchnorm1d, pooling: MaxPool1d, binarize: Binarize
+    ):
+        seq = SequentialBuilder()
+        seq.append(conv).append(pooling).append(bnorm).append(binarize)
+        return seq.build()
+
+    @pytest.fixture(scope="class")
+    def expected(
+        self, conv: Conv1d, bnorm: Batchnorm1d, pooling: MaxPool1d, binarize: Binarize
+    ):
+        seq = SequentialBuilder()
+        seq.append(conv).append(bnorm).append(binarize).append(pooling)
+        return seq.build()
+
+    @pytest.fixture(scope="class")
+    def reordered(self, seq: Implementation):
+        return reorder_blocks(seq)
+
+    def test_edges_are_in_correct_order(
+        self, reordered: Implementation, expected: Implementation
+    ):
+        assert set(reordered.edges.keys()) == set(expected.edges.keys())
+
+    def test_conv_data_is_copied(self, reordered: Implementation, seq: Implementation):
+        assert reordered.nodes["conv"] == seq.nodes["conv"]
+
+    def test_bnorm_data_is_copied(self, reordered: Implementation, seq: Implementation):
+        assert reordered.nodes["bnorm"] == seq.nodes["bnorm"]
+
+    def test_binarize_data_is_copied(
+        self, reordered: Implementation, seq: Implementation
+    ):
+        assert reordered.nodes["bin"] == seq.nodes["bin"]
+
+    def test_pooling_data_is_copied(
+        self, reordered: Implementation, seq: Implementation
+    ):
+        assert reordered.nodes["pool"] == seq.nodes["pool"]

--- a/uv.lock
+++ b/uv.lock
@@ -150,6 +150,18 @@ wheels = [
 ]
 
 [[package]]
+name = "cattrs"
+version = "24.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/65/af6d57da2cb32c076319b7489ae0958f746949d407109e3ccf4d115f147c/cattrs-24.1.2.tar.gz", hash = "sha256:8028cfe1ff5382df59dd36474a86e02d817b06eaf8af84555441bac915d2ef85", size = 426462 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/d5/867e75361fc45f6de75fe277dd085627a9db5ebb511a87f27dc1396b5351/cattrs-24.1.2-py3-none-any.whl", hash = "sha256:67c7495b760168d931a10233f979b28dc04daf853b30752246f4f8471c6d68d0", size = 66446 },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.1.31"
 source = { registry = "https://pypi.org/simple" }
@@ -497,6 +509,7 @@ lint = [
     { name = "ruff" },
 ]
 lsp = [
+    { name = "esbonio" },
     { name = "pylsp-mypy" },
     { name = "pylsp-rope" },
     { name = "python-lsp-server" },
@@ -563,6 +576,7 @@ lint = [
     { name = "ruff", specifier = ">=0.9.0" },
 ]
 lsp = [
+    { name = "esbonio", specifier = ">=0.16.5" },
     { name = "pylsp-mypy", specifier = ">=0.6.9" },
     { name = "pylsp-rope", specifier = ">=0.1.17" },
     { name = "python-lsp-server", specifier = ">=1.12.0" },
@@ -577,6 +591,21 @@ testing = [
 ]
 utils = [{ name = "rust-just", specifier = ">=1.38.0" }]
 versioning = [{ name = "towncrier", specifier = ">=24.8.0" }]
+
+[[package]]
+name = "esbonio"
+version = "0.16.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pygls" },
+    { name = "pyspellchecker" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/c5/0c89af3da1f3133b53f3ba8ae677ed4d4ddff33eec50dbf32c95e01ed2d2/esbonio-0.16.5.tar.gz", hash = "sha256:acab2e16c6cf8f7232fb04e0d48514ce50566516b1f6fcf669ccf2f247e8b10f", size = 145347 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/ca/a0296fca375d4324f471bb34d2ce8a585b48fb9eae21cf9abe00913eb899/esbonio-0.16.5-py3-none-any.whl", hash = "sha256:04ba926e3603f7b1fde1abc690b47afd60749b64b1029b6bce8e1de0bb284921", size = 170830 },
+]
 
 [[package]]
 name = "executing"
@@ -1035,6 +1064,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2a/ae/bb56c6828e4797ba5a4821eec7c43b8bf40f69cda4d4f5f8c8a2810ec96a/linkify-it-py-2.0.3.tar.gz", hash = "sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048", size = 27946 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl", hash = "sha256:6bcbc417b0ac14323382aef5c5192c0075bf8a9d6b41820a2b66371eac6b6d79", size = 19820 },
+]
+
+[[package]]
+name = "lsprotocol"
+version = "2023.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/f6/6e80484ec078d0b50699ceb1833597b792a6c695f90c645fbaf54b947e6f/lsprotocol-2023.0.1.tar.gz", hash = "sha256:cc5c15130d2403c18b734304339e51242d3018a05c4f7d0f198ad6e0cd21861d", size = 69434 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/37/2351e48cb3309673492d3a8c59d407b75fb6630e560eb27ecd4da03adc9a/lsprotocol-2023.0.1-py3-none-any.whl", hash = "sha256:c75223c9e4af2f24272b14c6375787438279369236cd568f596d4951052a60f2", size = 70826 },
 ]
 
 [[package]]
@@ -1664,6 +1706,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pygls"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cattrs" },
+    { name = "lsprotocol" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/b9/41d173dad9eaa9db9c785a85671fc3d68961f08d67706dc2e79011e10b5c/pygls-1.3.1.tar.gz", hash = "sha256:140edceefa0da0e9b3c533547c892a42a7d2fd9217ae848c330c53d266a55018", size = 45527 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/19/b74a10dd24548e96e8c80226cbacb28b021bc3a168a7d2709fb0d0185348/pygls-1.3.1-py3-none-any.whl", hash = "sha256:6e00f11efc56321bdeb6eac04f6d86131f654c7d49124344a9ebb968da3dd91e", size = 56031 },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1714,6 +1769,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216 },
+]
+
+[[package]]
+name = "pyspellchecker"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/5d/86d94aceb9c0813f27004ec71c036d8ec6a6324d989854ff0fe13fe036dc/pyspellchecker-0.8.2.tar.gz", hash = "sha256:2b026be14a162ba810bdda8e5454c56e364f42d3b9e14aeff31706e5ebcdc78f", size = 7149207 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/8e/7c79443d302a80cfd59bc365938d51e36e7e9aa7ce8ab1d8a0ca0c8e6065/pyspellchecker-0.8.2-py3-none-any.whl", hash = "sha256:4fee22e1859c5153c3bc3953ac3041bf07d4541520b7e01901e955062022290a", size = 7147898 },
 ]
 
 [[package]]


### PR DESCRIPTION
Introduces a SequentialReorderer that uses the graph
rewriter and ir.Implementation to create new graphs
where a given pattern is reordered as specified
by the client. All data from the old graph (including
node data) will be copied to the new graph.

This is essential for many optimizations we want
to perform, before or while going down to low level ir.