### PR TITLE
feat(ir_transforms): move subgraph to separate implementation

### DIFF
--- a/elasticai/creator/ir_transforms/__init__.py
+++ b/elasticai/creator/ir_transforms/__init__.py
@@ -1,3 +1,5 @@
-from .reorder import NodeConstraint, SequenceReorderer
+from .constraint import NodeConstraint
+from .reorder import SequenceReorderer
+from .subgraph_extraction import SubgraphExtractor
 
-__all__ = ["SequenceReorderer", "NodeConstraint"]
+__all__ = ["SequenceReorderer", "NodeConstraint", "SubgraphExtractor"]

--- a/elasticai/creator/ir_transforms/_matcher.py
+++ b/elasticai/creator/ir_transforms/_matcher.py
@@ -1,0 +1,34 @@
+from typing import Generic
+
+import elasticai.creator.graph as g
+from elasticai.creator import ir
+from elasticai.creator.graph import Graph
+
+from ._types import GNode, PNode
+from .constraint import NodeConstraint
+
+
+class Matcher(Generic[PNode, GNode]):
+    def __init__(
+        self,
+        pattern: ir.Implementation[PNode, ir.Edge],
+        graph: ir.Implementation[GNode, ir.Edge],
+        node_constraint: NodeConstraint[PNode, GNode],
+    ):
+        self.pattern = pattern
+        self.graph = graph
+        self._node_constraint = node_constraint
+
+    def set_graph(self, graph: ir.Implementation[GNode, ir.Edge]) -> None:
+        self.graph = graph
+
+    def node_constraint(self, pattern_node: str, graph_node: str) -> bool:
+        return self._node_constraint(
+            pattern_node=self.pattern.nodes[pattern_node],
+            graph_node=self.graph.nodes[graph_node],
+        )
+
+    def __call__(self, pattern: Graph[str], graph: Graph[str]) -> list[dict[str, str]]:
+        return g.find_subgraphs(
+            pattern=pattern, graph=graph, node_constraint=self.node_constraint
+        )

--- a/elasticai/creator/ir_transforms/_types.py
+++ b/elasticai/creator/ir_transforms/_types.py
@@ -1,0 +1,7 @@
+from typing import TypeVar
+
+from elasticai.creator import ir
+
+PNode = TypeVar("PNode", bound=ir.Node)
+GNode = TypeVar("GNode", bound=ir.Node)
+# This is a type alias for a tuple of two implementations

--- a/elasticai/creator/ir_transforms/constraint.py
+++ b/elasticai/creator/ir_transforms/constraint.py
@@ -1,0 +1,10 @@
+from typing import Protocol, TypeVar
+
+from elasticai.creator import ir
+
+PNodeCon = TypeVar("PNodeCon", bound=ir.Node, contravariant=True)
+GNodeCon = TypeVar("GNodeCon", bound=ir.Node, contravariant=True)
+
+
+class NodeConstraint(Protocol[PNodeCon, GNodeCon]):
+    def __call__(self, *, pattern_node: PNodeCon, graph_node: GNodeCon) -> bool: ...

--- a/elasticai/creator/ir_transforms/reorder.py
+++ b/elasticai/creator/ir_transforms/reorder.py
@@ -1,11 +1,13 @@
 import copy
 from collections.abc import Sequence
-from typing import Protocol, TypeVar, cast
+from typing import TypeVar, cast
 
 from elasticai.creator import graph as g
 from elasticai.creator import ir
-from elasticai.creator.graph import Graph
 from elasticai.creator.torch2ir import Implementation
+
+from ._matcher import Matcher as _Matcher
+from .constraint import NodeConstraint
 
 
 def build_sequential_pattern(
@@ -24,39 +26,6 @@ def build_sequential_pattern(
 
 PNode = TypeVar("PNode", bound=ir.Node)
 GNode = TypeVar("GNode", bound=ir.Node)
-
-PNodeCon = TypeVar("PNodeCon", bound=ir.Node, contravariant=True)
-GNodeCon = TypeVar("GNodeCon", bound=ir.Node, contravariant=True)
-
-
-class NodeConstraint(Protocol[PNodeCon, GNodeCon]):
-    def __call__(self, *, pattern_node: PNodeCon, graph_node: GNodeCon) -> bool: ...
-
-
-class _Matcher:
-    def __init__(
-        self,
-        pattern: ir.Implementation[ir.Node, ir.Edge],
-        graph: ir.Implementation[ir.Node, ir.Edge],
-        node_constraint: NodeConstraint[ir.Node, ir.Node],
-    ):
-        self.pattern = pattern
-        self.graph = graph
-        self._node_constraint = node_constraint
-
-    def set_graph(self, graph: ir.Implementation[ir.Node, ir.Edge]) -> None:
-        self.graph = graph
-
-    def node_constraint(self, pattern_node: str, graph_node: str) -> bool:
-        return self._node_constraint(
-            pattern_node=self.pattern.nodes[pattern_node],
-            graph_node=self.graph.nodes[graph_node],
-        )
-
-    def __call__(self, pattern: Graph[str], graph: Graph[str]) -> list[dict[str, str]]:
-        return g.find_subgraphs(
-            pattern=pattern, graph=graph, node_constraint=self.node_constraint
-        )
 
 
 class SequenceReorderer:

--- a/elasticai/creator/ir_transforms/subgraph_extraction.py
+++ b/elasticai/creator/ir_transforms/subgraph_extraction.py
@@ -1,0 +1,106 @@
+from typing import Any, Generic, cast
+
+from elasticai.creator import graph as g
+from elasticai.creator import ir
+
+from ._matcher import Matcher
+from ._types import GNode, PNode
+from .constraint import NodeConstraint
+
+
+class SubgraphExtractor(Generic[PNode, GNode]):
+    def __init__(
+        self,
+        pattern: ir.Implementation[PNode, ir.Edge],
+        node_constraint: NodeConstraint[PNode, GNode],
+    ):
+        """Extract pattern from a graph, where it matches the node constraint.
+
+        The `"input"` and `"output"` nodes of the pattern will automatically be used
+        as the interface (see [`g.GraphRewriter`](#elasticai.creator.graph.GraphRewriter) for more details).
+
+        The call to `.extract()` will return two new implementations:
+          1. where the pattern has been replaced by a single node
+          2. the extracted subgraph implementation
+
+
+        Example:
+        ```python
+        # Define a pattern to match (e.g., two nodes of type 'T' in sequence)
+        pattern = (ir.Implementation(data=dict(name="pattern", type="P"))
+                    .add_node(name="input", type="any")
+                    .add_node(name="output", type="any")
+                    .add_node(name="a", type="T")
+                    .add_node(name="b", type="T")
+                    .add_edge(src="input", dst="a")
+                    .add_edge(src="a", dst="b")
+                    .add_edge(src="b", dst="output"))
+
+        # Define a constraint for node matching
+        def constraint(pattern_node: ir.Node, graph_node: ir.Node) -> bool:
+            return pattern_node.type == "any" or pattern_node.type == graph_node.type
+
+        # Create and use the extractor
+        extractor = SubgraphExtractor(pattern, node_constraint=constraint)
+        new_impl, subgraph = extractor.extract(implementation)
+        ```
+        """
+        self.pattern = pattern
+        impl = cast(  # cast is ok, as graph will remain empty until extract is called
+            ir.Implementation[GNode, ir.Edge],
+            ir.Implementation(graph=pattern.graph.new()),
+        )
+        self._matcher = Matcher(
+            pattern=pattern,
+            graph=impl,
+            node_constraint=node_constraint,
+        )
+        self.replacement = (
+            pattern.graph.new()
+            .add_edge("input", self.pattern.name)
+            .add_edge(self.pattern.name, "output")
+        )
+
+    def extract(
+        self, impl: ir.Implementation[GNode, ir.Edge]
+    ) -> tuple[
+        ir.Implementation[ir.Node, ir.Edge], ir.Implementation[ir.Node, ir.Edge]
+    ]:
+        """Extract a pattern from `impl` returning the new implementation and the extracted subgraph implementation.
+
+        The subgraph will be replaced by a node with the same name/type as the pattern.
+        Its `implementation` field will point to the newly extracted subgraph implementation.
+        """
+        interface = impl.graph.new().add_node("input").add_node("output")
+        lhs = {"input": "input", "output": "output"}
+        rhs = lhs
+        self._matcher.graph = impl
+        rewriter = g.GraphRewriter(
+            replacement=self.replacement,
+            match=self._matcher,
+            pattern=self.pattern.graph,
+            interface=interface,
+            lhs=lhs,
+            rhs=rhs,
+        )
+        result = rewriter.rewrite(impl.graph)
+        subgraph = ir.Implementation(graph=impl.graph.new())
+        subgraph_nodes = set(result.pattern_to_original.values())
+        for node in subgraph_nodes:
+            for successor in impl.successors(node).values():
+                if successor.name in subgraph_nodes:
+                    subgraph.add_edge(src=node, dst=successor.name)
+            subgraph.add_node(impl.nodes[node])
+
+        new_data = impl.data.copy()
+        for node in subgraph_nodes - set(lhs.keys()):
+            cast(dict[str, Any], new_data["nodes"]).pop(node)
+
+        new_node_name = result.replacement_to_new[self.pattern.name]
+        cast(dict[str, Any], new_data["nodes"])[new_node_name] = {
+            "name": new_node_name,
+            "type": self.pattern.data["type"],
+            "implementation": self.pattern.name,
+        }
+
+        return ir.Implementation(data=new_data, graph=result.new_graph), subgraph

--- a/tests/unit_tests/ir_transforms/subgraph_extraction_test.py
+++ b/tests/unit_tests/ir_transforms/subgraph_extraction_test.py
@@ -1,0 +1,112 @@
+import pytest
+
+from elasticai.creator import graph, ir
+from elasticai.creator import ir_transforms as itr
+
+
+class TestExtractTwoNodesFromImpl:
+    @pytest.fixture
+    def impl(self):
+        return (
+            ir.Implementation(
+                data=dict(name="impl"),
+                graph=graph.BaseGraph(),
+            )
+            .add_node(name="input", type="input")
+            .add_node(name="output", type="output")
+            .add_node(name="a", type="t")
+            .add_node(name="b", type="t")
+            .add_edge(src="input", dst="a")
+            .add_edge(src="a", dst="b")
+            .add_edge(src="b", dst="output")
+        )
+
+    @pytest.fixture
+    def pattern(self):
+        return (
+            ir.Implementation(
+                data=dict(name="pattern", type="p"),
+                graph=graph.BaseGraph(),
+            )
+            .add_node(name="input", type="any")
+            .add_node(name="output", type="any")
+            .add_node(name="a", type="t")
+            .add_node(name="b", type="t")
+            .add_edge(src="input", dst="a")
+            .add_edge(src="a", dst="b")
+            .add_edge(src="b", dst="output")
+        )
+
+    @pytest.fixture
+    def constraint(self):
+        def _constraint(pattern_node: ir.Node, graph_node: ir.Node) -> bool:
+            return pattern_node.type == "any" or pattern_node.type == graph_node.type
+
+        return _constraint
+
+    @pytest.fixture
+    def extraction_result(
+        self,
+        impl: ir.Implementation[ir.Node, ir.Edge],
+        pattern: ir.Implementation[ir.Node, ir.Edge],
+        constraint,
+    ):
+        return itr.SubgraphExtractor(pattern, node_constraint=constraint).extract(impl)
+
+    @pytest.fixture
+    def new_graph(
+        self,
+        extraction_result: tuple[
+            ir.Implementation[ir.Node, ir.Edge], ir.Implementation[ir.Node, ir.Edge]
+        ],
+    ):
+        return extraction_result[0]
+
+    @pytest.fixture
+    def subgraph(
+        self,
+        extraction_result: tuple[
+            ir.Implementation[ir.Node, ir.Edge], ir.Implementation[ir.Node, ir.Edge]
+        ],
+    ):
+        return extraction_result[1]
+
+    @pytest.fixture
+    def test_new_graph_has_all_required_nodes(
+        self, new_graph: ir.Implementation[ir.Node, ir.Edge]
+    ):
+        assert new_graph.data["nodes"] == {
+            "input": {"type": "input", "name": "input"},
+            "output": {"type": "output", "name": "output"},
+            "pattern": {"name": "pattern", "type": "p", "implementation": "pattern"},
+        }
+
+    def test_new_graph_has_all_required_edges(
+        self,
+        new_graph: ir.Implementation[ir.Node, ir.Edge],
+    ):
+        assert set(new_graph.edges.keys()) == {
+            ("input", "pattern"),
+            ("pattern", "output"),
+        }
+
+    def test_subgraph_has_all_required_nodes(
+        self,
+        subgraph: ir.Implementation[ir.Node, ir.Edge],
+    ):
+        assert subgraph.data["nodes"] == {
+            "input": {"name": "input", "type": "input"},
+            "output": {"name": "output", "type": "output"},
+            "a": {"name": "a", "type": "t"},
+            "b": {"name": "b", "type": "t"},
+        }
+
+    def test_subgraph_has_all_required_edges(
+        self,
+        subgraph: ir.Implementation[ir.Node, ir.Edge],
+    ):
+        assert set(subgraph.edges.keys()) == {
+            ("input", "a"),
+            ("a", "b"),
+            ("b", "output"),
+        }


### PR DESCRIPTION
Adds a function that allows us to move the subgraph of an implementation to a separate implementation
instance, replacing the whole subgraph by a node referring to the new implementation.

This is useful for two reasons

* reduced code complexity by handling complex subgraphs separately during a lowering pass 
* identify and assign a name to whole subgraphs, so subsequent steps can treat them as single (grouped) entity