### PR TITLE
fix(template)!: return str instead of str.Template from builder

### DIFF
--- a/elasticai/creator/ir2vhdl/__init__.py
+++ b/elasticai/creator/ir2vhdl/__init__.py
@@ -1,5 +1,3 @@
-from elasticai.creator.template import Template
-
 from .ir2vhdl import (
     Code,
     Edge,

--- a/elasticai/creator/ir2vhdl/vhdl_template.py
+++ b/elasticai/creator/ir2vhdl/vhdl_template.py
@@ -1,6 +1,7 @@
+from string import Template as _pyTemplate
+
 from elasticai.creator.template import (
     AnalysingTemplateParameter,
-    Template,
     TemplateBuilder,
     TemplateParameter,
 )
@@ -54,6 +55,14 @@ class ValueTemplateParameter(TemplateParameter):
         return f"{match['def']} := ${self.name}"
 
 
+class _Template:
+    def __init__(self, data: str):
+        self._data = _pyTemplate(data)
+
+    def render(self, parameters: dict[str, str]) -> str:
+        return self._data.substitute(parameters)
+
+
 class EntityTemplateDirector:
     def __init__(self):
         self._builder = TemplateBuilder()
@@ -69,5 +78,5 @@ class EntityTemplateDirector:
         self._builder.add_parameter(ValueTemplateParameter(name))
         return self
 
-    def build(self) -> Template:
-        return self._builder.build()
+    def build(self) -> _Template:
+        return _Template(self._builder.build())

--- a/elasticai/creator/template.py
+++ b/elasticai/creator/template.py
@@ -2,17 +2,7 @@ from collections.abc import Callable
 from functools import singledispatchmethod
 from re import Match, Pattern
 from re import compile as _regex_compile
-from string import Template as _pyTemplate
 from typing import Iterable, Protocol, runtime_checkable
-
-
-class Template(Protocol):
-    def render(self, mapping: dict[str, str]) -> str:
-        """Replace all parameters in the template by the values provided by mapping.
-
-        Will raise a `KeyError` if not all parameter values are defined in mapping.
-        """
-        ...
 
 
 @runtime_checkable
@@ -131,7 +121,7 @@ class TemplateBuilder:
         self._analysing_template_parameters: dict[str, _AnalyseParameterTypeWrapper] = (
             dict()
         )
-        self._template = _pyTemplate("")
+        self._template = ""
         self._cached_template_is_valid = False
 
     def set_prototype(
@@ -178,12 +168,12 @@ class TemplateBuilder:
 
         return adder
 
-    def build(self) -> Template:
+    def build(self) -> str:
         if not self._cached_template_is_valid:
             self._analyse()
             regex = self._build_replacement_regex()
-            self._template = _pyTemplate(regex.sub(self._replace, self._prototype))
-        return _Template(self._template)
+            self._template = regex.sub(self._replace, self._prototype)
+        return self._template
 
     def _replace(self, m: Match) -> str:
         type_name = m.lastgroup
@@ -294,15 +284,3 @@ def _demangle_capture_group_names(name, match: dict[str, str]) -> dict[str, str]
             k = k.removeprefix("_")
             new_dict[k] = v
     return new_dict
-
-
-class _Template:
-    def __init__(self, template: _pyTemplate) -> None:
-        self._template = template
-
-    def render(self, mapping: dict[str, str]) -> str:
-        """Replace all parameters in the template by the values provided by mapping.
-
-        Will raise a `KeyError` if not all parameter values are defined in mapping.
-        """
-        return self._template.substitute(mapping)

--- a/tests/unit_tests/ir2verilog_test.py
+++ b/tests/unit_tests/ir2verilog_test.py
@@ -11,7 +11,8 @@ class TestVerilogTemplate:
         )
 
         assert (
-            template.render({"DATA_WIDTH": "'h16"}) == "localparam DATA_WIDTH = 'h16;"
+            template.substitute({"DATA_WIDTH": "'h16"})
+            == "localparam DATA_WIDTH = 'h16;"
         )
 
     def test_can_set_parameter_before_comma(self):
@@ -22,7 +23,10 @@ class TestVerilogTemplate:
             .build()
         )
 
-        assert template.render({"DATA_WIDTH": "'h16"}) == "parameter DATA_WIDTH = 'h16,"
+        assert (
+            template.substitute({"DATA_WIDTH": "'h16"})
+            == "parameter DATA_WIDTH = 'h16,"
+        )
 
     def test_keep_new_line_between_define_switches(self):
         template = (
@@ -34,7 +38,7 @@ class TestVerilogTemplate:
         )
 
         assert (
-            template.render(
+            template.substitute(
                 {
                     "DATA_WIDTH": True,
                     "DATA_LENGTH": True,
@@ -53,7 +57,8 @@ class TestVerilogTemplate:
         )
 
         assert (
-            template.render({"DATA_WIDTH": "'h16"}) == "parameter DATA_WIDTH = 'h16\n"
+            template.substitute({"DATA_WIDTH": "'h16"})
+            == "parameter DATA_WIDTH = 'h16\n"
         )
 
     def test_can_undefine_data_width(self):
@@ -65,7 +70,7 @@ class TestVerilogTemplate:
         )
         template.undef("DATA_WIDTH")
         assert (
-            template.render({})
+            template.substitute({})
             == """// automatically disabled\n// `define DATA_WIDTH 8"""
         )
 
@@ -77,7 +82,7 @@ class TestVerilogTemplate:
             .build()
         )
         template.define("DATA_WIDTH")
-        assert template.render({}) == "`define DATA_WIDTH 8"
+        assert template.substitute({}) == "`define DATA_WIDTH 8"
 
     def test_can_replace_module_name(self):
         template = (
@@ -87,7 +92,7 @@ class TestVerilogTemplate:
             .build()
         )
         assert (
-            template.render({"module_name": "FILTER_FIR_MY_NAME_HALF"})
+            template.substitute({"module_name": "FILTER_FIR_MY_NAME_HALF"})
             == "module FILTER_FIR_MY_NAME_HALF#("
         )
 
@@ -99,7 +104,7 @@ class TestVerilogTemplate:
             .build()
         )
         assert (
-            template.render({"module_name": "FILTER_FIR_HALF"})
+            template.substitute({"module_name": "FILTER_FIR_HALF"})
             == "`define FILTER_FIR_HALF_DATA_WIDTH 8"
         )
 
@@ -111,6 +116,6 @@ class TestVerilogTemplate:
             .build()
         )
         assert (
-            template.render({"module_name": "FILTER_FIR_HALF"})
+            template.substitute({"module_name": "FILTER_FIR_HALF"})
             == "`define FILTER_FIR_HALF_DATA_WIDTH 8\nFILTER_FIR_HALF_DATA_WIDTH + 10"
         )


### PR DESCRIPTION
This allows clients to decide on their own how
the parameters in the template have to be replaced. E.g., in verilog the default delimiter `$` is
a language token. Having clients wrap the string
in a template object makes modifications like this one trivial.

Closes #607