### PR TITLE
feat(graph): find all non-overlapping subgraphs

### DIFF
--- a/elasticai/creator/graph/__init__.py
+++ b/elasticai/creator/graph/__init__.py
@@ -7,12 +7,13 @@ from .graph_iterators import (
 )
 from .graph_rewriting import GraphRewriter, RewriteResult
 from .name_generation import NameRegistry
-from .subgraph_matching import find_subgraphs
+from .subgraph_matching import find_all_subgraphs, find_subgraph
 
 __all__ = [
     "BaseGraph",
     "Graph",
-    "find_subgraphs",
+    "find_all_subgraphs",
+    "find_subgraph",
     "GraphRewriter",
     "bfs_iter_down",
     "bfs_iter_up",

--- a/elasticai/creator/graph/subgraph_matching.py
+++ b/elasticai/creator/graph/subgraph_matching.py
@@ -2,19 +2,24 @@ from typing import TypeVar
 
 from elasticai.creator.graph._types import NodeConstraintFn
 
-from .vf2 import match as _match
+from .vf2 import find_all_matches, match
 
 TP = TypeVar("TP")
 T = TypeVar("T")
 
 
+class SubGraphMatchError(Exception):
+    def __init__(self):
+        super().__init__("No matching subgraph found")
+
+
 def find_subgraph(
     pattern, graph, node_constraint: NodeConstraintFn[TP, T]
 ) -> dict[TP, T]:
-    return _match(pattern, graph, node_constraint)
+    return match(pattern, graph, node_constraint)
 
 
-def find_subgraphs(
+def find_all_subgraphs(
     pattern, graph, node_constraint: NodeConstraintFn[TP, T]
 ) -> list[dict[TP, T]]:
-    return [_match(pattern, graph, node_constraint)]
+    return find_all_matches(pattern, graph, node_constraint)

--- a/elasticai/creator/graph/vf2/__init__.py
+++ b/elasticai/creator/graph/vf2/__init__.py
@@ -1,3 +1,3 @@
-from .matching import match
+from .matching import MatchError, find_all_matches, match
 
-__all__ = ["match"]
+__all__ = ["match", "find_all_matches", "MatchError"]

--- a/elasticai/creator/ir_transforms/reorder.py
+++ b/elasticai/creator/ir_transforms/reorder.py
@@ -54,7 +54,7 @@ class _Matcher:
         )
 
     def __call__(self, pattern: Graph[str], graph: Graph[str]) -> list[dict[str, str]]:
-        return g.find_subgraphs(
+        return g.find_all_subgraphs(
             pattern=pattern, graph=graph, node_constraint=self.node_constraint
         )
 

--- a/tests/unit_tests/graph/utils.py
+++ b/tests/unit_tests/graph/utils.py
@@ -34,7 +34,7 @@ def find_matches(graph, pattern) -> list[dict[str, str]]:
     def node_constraint(pattern_node, graph_node):
         return graph.data[graph_node] == pattern.data[pattern_node]
 
-    return g.find_subgraphs(
+    return g.find_all_subgraphs(
         pattern=pattern.wrapped, graph=graph.wrapped, node_constraint=node_constraint
     )
 
@@ -54,7 +54,7 @@ class Matcher:
     def __call__(
         self, graph: g.Graph[str], pattern: g.Graph[str]
     ) -> list[dict[str, str]]:
-        return g.find_subgraphs(
+        return g.find_all_subgraphs(
             pattern=pattern, graph=graph, node_constraint=self._node_constraint
         )
 

--- a/tests/unit_tests/graph/vf2/match_test.py
+++ b/tests/unit_tests/graph/vf2/match_test.py
@@ -1,7 +1,8 @@
 import pytest
 
 import elasticai.creator.graph as gr
-from elasticai.creator.graph.vf2 import match
+from elasticai.creator.graph.vf2 import find_all_matches, match
+from elasticai.creator.graph.vf2.matching import MatchError
 
 
 @pytest.fixture
@@ -30,8 +31,8 @@ def test_match_single_edge_two_times(create_graph):
     p = create_graph()
     add_path(p, "a->b")
     g = create_graph()
-    add_path(g, "0->1->2")
-    assert match(p, g) in [{"a": "0", "b": "1"}, {"a": "1", "b": "2"}]
+    add_path(g, "0->1->2->3")
+    assert find_all_matches(p, g) == [{"a": "0", "b": "1"}, {"a": "2", "b": "3"}]
 
 
 def test_double_edge(create_graph):
@@ -60,7 +61,7 @@ def test_donot_match_partially_with_single_edge(create_graph):
     add_path(p, "a->b->c")
     g = create_graph()
     add_path(g, "0->1")
-    assert match(p, g) == dict()
+    pytest.raises(MatchError, match, p, g)
 
 
 def test_donot_match_partially_four_to_three_edges(create_graph):
@@ -68,7 +69,7 @@ def test_donot_match_partially_four_to_three_edges(create_graph):
     add_path(p, "a->b->c->d->e")
     g = create_graph()
     add_path(g, "0->1->2->3")
-    assert match(p, g) == dict()
+    pytest.raises(MatchError, match, p, g)
 
 
 def test_match_acyclic_pattern_to_cyclic_graph(create_graph):


### PR DESCRIPTION
In most cases we want to find/replace all
non-overlapping subgraphs specified by a
given pattern. This extends the vf2 based
algorithm to find all occurences of the
pattern instead of just the first one.