### PR TITLE
refactor(graph): rename dfs_preorder to dfs_iter

### DIFF
--- a/elasticai/creator/graph/__init__.py
+++ b/elasticai/creator/graph/__init__.py
@@ -3,7 +3,7 @@ from .graph import Graph
 from .graph_iterators import (
     bfs_iter_down,
     bfs_iter_up,
-    dfs_pre_order,
+    dfs_iter,
 )
 from .graph_rewriting import GraphRewriter, RewriteResult
 from .name_generation import NameRegistry
@@ -17,7 +17,7 @@ __all__ = [
     "GraphRewriter",
     "bfs_iter_down",
     "bfs_iter_up",
-    "dfs_pre_order",
+    "dfs_iter",
     "NameRegistry",
     "RewriteResult",
 ]

--- a/elasticai/creator/graph/graph_iterators.py
+++ b/elasticai/creator/graph/graph_iterators.py
@@ -8,7 +8,7 @@ class NodeNeighbourFn(Protocol[HashableT]):
     def __call__(self, node: HashableT) -> Iterable[HashableT]: ...
 
 
-def dfs_pre_order(successors: NodeNeighbourFn, start: HashableT) -> Iterator[HashableT]:
+def dfs_iter(successors: NodeNeighbourFn, start: HashableT) -> Iterator[HashableT]:
     visited: set[HashableT] = set()
 
     def visit(nodes: tuple[HashableT, ...]):

--- a/elasticai/creator_plugins/time_multiplexed_sequential/src/__init__.py
+++ b/elasticai/creator_plugins/time_multiplexed_sequential/src/__init__.py
@@ -3,7 +3,7 @@ from typing import ParamSpec
 
 import elasticai.creator.plugin as _pl
 from elasticai.creator.function_utils import FunctionDecorator
-from elasticai.creator.graph import dfs_pre_order as dfs_iter
+from elasticai.creator.graph import dfs_iter
 from elasticai.creator.ir import RequiredField
 from elasticai.creator.ir2vhdl import (
     Edge,

--- a/tests/unit_tests/graph/graph_test.py
+++ b/tests/unit_tests/graph/graph_test.py
@@ -1,5 +1,7 @@
+import pytest
+
 from elasticai.creator.graph import BaseGraph as GraphDelegate
-from elasticai.creator.graph import bfs_iter_up, dfs_pre_order
+from elasticai.creator.graph import bfs_iter_up, dfs_iter
 
 
 def test_yield_node_in_case_it_has_no_successors():
@@ -43,35 +45,66 @@ def test_iterating_breadth_first_upwards():
     assert actual == ("3", "6", "1", "4", "2", "0")
 
 
-def test_iterating_depth_first_preorder():
-    g = GraphDelegate()
-    """
-             0
-             |
-          /-----\
-          |     |
-          1     2
-          | /---+
-          |/    |
-          3     4
-          |     |
-          |     6
-          |/----+
-          5
-    """
-    g = GraphDelegate.from_dict(
-        {
-            "0": ["1", "2"],
-            "1": ["3"],
-            "2": ["3", "4"],
-            "3": ["5"],
-            "4": ["6"],
-            "6": ["5"],
-        }
-    )
+@pytest.mark.parametrize(
+    ["adjacencies", "expected"],
+    [
+        (
+            #      0
+            #      |
+            #   /-----\
+            #   |     |
+            #   1     2
+            #   | /---+
+            #   |/    |
+            #   3     4
+            #   |     |
+            #   |     6
+            #   |/----+
+            #   5
+            {
+                "0": ["1", "2"],
+                "1": ["3"],
+                "2": ["3", "4"],
+                "3": ["5"],
+                "4": ["6"],
+                "6": ["5"],
+            },
+            {
+                ("0", "2", "4", "1", "3", "5", "6"),
+                ("0", "2", "3", "5", "4", "6", "1"),
+                ("0", "1", "3", "5", "2", "4", "6"),
+                ("0", "2", "4", "6", "5", "1", "3"),
+                ("0", "2", "4", "6", "5", "3", "1"),
+            },
+        ),
+        (
+            {
+                "0": ["1", "4"],
+                "1": ["2"],
+                "2": ["3"],
+                "3": [],
+                "4": ["5", "6"],
+                "5": [],
+                "6": [],
+            },
+            {
+                ("0", "4", "5", "6", "1", "2", "3"),
+                ("0", "4", "6", "5", "1", "2", "3"),
+                ("0", "1", "2", "3", "4", "5", "6"),
+                ("0", "1", "2", "3", "4", "6", "5"),
+            },
+        ),
+        (
+            {"0": ["1", "2"], "1": [], "2": []},
+            {
+                ("0", "1", "2"),
+                ("0", "2", "1"),
+            },
+        ),
+    ],
+)
+def test_iterate_dfs(adjacencies, expected):
+    g = GraphDelegate.from_dict(adjacencies)
 
-    actual = tuple(dfs_pre_order(g.get_successors, "0"))
-    expected = {
-        ("0", "2", "4", "6", "5", "3", "1"),
-    }
+    actual = tuple(dfs_iter(g.get_successors, "0"))
     assert actual in expected


### PR DESCRIPTION
Pre/In/Postorder traversal makes no sense in the
context of general graphs instead of trees.

Additionally the commit extends the test cases
to make the dfs more explicit and make it easier
to narrow down problems.