### PR TITLE
refactor(graph): only require a single match in rewriter

### DIFF
--- a/elasticai/creator/ir_transforms/reorder.py
+++ b/elasticai/creator/ir_transforms/reorder.py
@@ -53,8 +53,8 @@ class _Matcher:
             graph_node=self.graph.nodes[graph_node],
         )
 
-    def __call__(self, pattern: Graph[str], graph: Graph[str]) -> list[dict[str, str]]:
-        return g.find_all_subgraphs(
+    def __call__(self, pattern: Graph[str], graph: Graph[str]) -> dict[str, str]:
+        return g.find_subgraph(
             pattern=pattern, graph=graph, node_constraint=self.node_constraint
         )
 

--- a/tests/unit_tests/graph/utils.py
+++ b/tests/unit_tests/graph/utils.py
@@ -51,10 +51,8 @@ class Matcher:
         assert self.graph is not None
         return self.graph.data[graph_node] == self.pattern.data[pattern_node]
 
-    def __call__(
-        self, graph: g.Graph[str], pattern: g.Graph[str]
-    ) -> list[dict[str, str]]:
-        return g.find_all_subgraphs(
+    def __call__(self, graph: g.Graph[str], pattern: g.Graph[str]) -> dict[str, str]:
+        return g.find_subgraph(
             pattern=pattern, graph=graph, node_constraint=self._node_constraint
         )
 


### PR DESCRIPTION
The rewrite algorithm cannot and does not need to
handle multiple matches. It should be up to
the caller to decide how each match should be
handled in case of multiple ones. 

This deprecates using functions that return
multiple matches as matchers for the graph rewriter.