### PR TITLE
feat(graph): filter subgraph matches for rewrite

### DIFF
--- a/elasticai/creator/graph/__init__.py
+++ b/elasticai/creator/graph/__init__.py
@@ -5,7 +5,14 @@ from .graph_iterators import (
     bfs_iter_up,
     dfs_iter,
 )
-from .graph_rewriting import DanglingEdgeError, GraphRewriter, RewriteResult, rewrite
+from .graph_rewriting import (
+    DanglingEdgeError,
+    GraphRewriter,
+    RewriteResult,
+    get_rewriteable_matches,
+    produces_dangling_edge,
+    rewrite,
+)
 from .name_generation import NameRegistry
 from .subgraph_matching import find_all_subgraphs, find_subgraph
 
@@ -19,7 +26,9 @@ __all__ = [
     "bfs_iter_up",
     "dfs_iter",
     "rewrite",
+    "get_rewriteable_matches",
     "NameRegistry",
     "RewriteResult",
+    "produces_dangling_edge",
     "DanglingEdgeError",
 ]

--- a/elasticai/creator/graph/graph_rewriting.py
+++ b/elasticai/creator/graph/graph_rewriting.py
@@ -1,6 +1,6 @@
 import copy
 import warnings
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from typing import Hashable, Protocol, TypeVar, runtime_checkable
 
 from .graph import Graph
@@ -35,10 +35,59 @@ class _SeqMatcher(Protocol):
     def __call__(self, *, pattern: Graph, graph: Graph) -> Sequence[dict[str, str]]: ...
 
 
-TP = TypeVar("TP", bound=Hashable)
 TG = TypeVar("TG", bound=Hashable)
 TR = TypeVar("TR", bound=Hashable)
 TI = TypeVar("TI", bound=Hashable)
+
+T = TypeVar("T", bound=Hashable)
+TP = TypeVar("TP", bound=Hashable)
+
+
+def get_rewriteable_matches(
+    original: Graph[T], matches: Iterable[dict[TP, T]], interface_nodes: Iterable[TP]
+) -> Iterator[dict[TP, T]]:
+    """Yield all matches that do produce dangling edges and do not overlap with previous matches.
+
+    The matches returned by this function are considerd safe to be rewritten in a single rewriting step in any order,
+    without having to run an additional matching step and
+    without producing dangling edges.
+
+    :param original: The original graph.
+    :param matches: The matches to check.
+    :param interface_nodes: All nodes in the pattern that are belong to the interface. These nodes are considered to be preserved during rewriting. Thus, the edges connected to these nodes are not considered dangling.
+
+    """
+    interface_nodes = set(interface_nodes)
+    matched_nodes: set[T] = set()
+    for match in matches:
+        if not produces_dangling_edge(original, match, interface_nodes):
+            new_matched_nodes = set(match.values())
+            if new_matched_nodes.isdisjoint(matched_nodes):
+                matched_nodes.update(match.values())
+                yield match
+
+
+def produces_dangling_edge(
+    graph: Graph[T], match: dict[TP, T], interface_nodes: Iterable[TP]
+) -> bool:
+    """Check if there are dangling edges attached to non-interface nodes."""
+
+    def is_dangling_edge(src: T, dst: T) -> bool:
+        return src not in match.values() or dst not in match.values()
+
+    def non_interface_nodes() -> Iterator[T]:
+        for pn, gn in match.items():
+            if pn not in interface_nodes:
+                yield gn
+
+    for gn in non_interface_nodes():
+        for gp in graph.predecessors[gn]:
+            if is_dangling_edge(gp, gn):
+                return True
+        for gs in graph.successors[gn]:
+            if is_dangling_edge(gn, gs):
+                return True
+    return False
 
 
 def rewrite(

--- a/tests/unit_tests/graph/dangling_edges_test.py
+++ b/tests/unit_tests/graph/dangling_edges_test.py
@@ -1,0 +1,30 @@
+from elasticai.creator import graph as gr
+from elasticai.creator.graph import produces_dangling_edge
+
+
+def test_catch_dangling_edge_d_b():
+    g = gr.BaseGraph().add_edge("a", "b").add_edge("b", "c").add_edge("d", "b")
+    match = {"0": "a", "1": "b", "2": "c"}
+    lhs = {"i0": "0", "i1": "2"}
+    assert produces_dangling_edge(g, match, lhs.values())
+
+
+def test_catch_dangling_edge_b_d():
+    g = gr.BaseGraph().add_edge("a", "b").add_edge("b", "c").add_edge("b", "d")
+    match = {"0": "a", "1": "b", "2": "c"}
+    lhs = {"i0": "0", "i1": "2"}
+    assert produces_dangling_edge(g, match, lhs.values())
+
+
+def test_let_pass_if_successor_b_is_in_interface():
+    g = gr.BaseGraph().add_edge("a", "b").add_edge("b", "c").add_edge("d", "b")
+    match = {"0": "a", "1": "b", "2": "c"}
+    lhs = {"i0": "0", "i1": "1"}
+    assert not produces_dangling_edge(g, match, lhs.values())
+
+
+def test_let_pass_if_predecessor_b_is_in_interface():
+    g = gr.BaseGraph().add_edge("a", "b").add_edge("b", "c").add_edge("b", "d")
+    match = {"0": "a", "1": "b", "2": "c"}
+    lhs = {"i0": "0", "i1": "1"}
+    assert not produces_dangling_edge(g, match, lhs.values())


### PR DESCRIPTION
We only want to rewrite non-overlapping matches,
where the rewrite would not produce dangling
references. The filter function will only
return the subgraph matches that fulfill this
condition.