### PR TITLE
refactor(graph): remove interface arg from rewrite function

### DIFF
--- a/elasticai/creator/graph/graph_rewriting.py
+++ b/elasticai/creator/graph/graph_rewriting.py
@@ -92,7 +92,6 @@ def produces_dangling_edge(
 
 def rewrite(
     *,
-    interface: Graph[str],
     replacement: Graph[str],
     original: Graph[str],
     match: Mapping[str, str],
@@ -150,13 +149,13 @@ def rewrite(
     :raises ValueError: If the `rhs` function is not injective (when different interface nodes map to the same replacement node).
     :raises DanglingEdgeError: if there is an edge between an unmatched node and a matched non-interface node.
     """
-    rhs_inversed = {rhs[node]: node for node in interface.nodes}
+    rhs_inversed = {rhs[node]: node for node in rhs}
     replacement_nodes_in_interface = set(rhs_inversed.keys())
-    if len(interface.nodes) != len(replacement_nodes_in_interface):
+    if len(rhs) != len(replacement_nodes_in_interface):
         raise ValueError(
             "Ensure the `rhs` function is injective. The `rhs` function should map each interface node to a unique replacement node."
         )
-    interface_nodes_in_pattern = set(lhs[node] for node in interface.nodes)
+    interface_nodes_in_pattern = set(lhs.values())
     interface_nodes_in_graph = set(match[node] for node in interface_nodes_in_pattern)
 
     new_graph: Graph = original.new()
@@ -306,7 +305,6 @@ class GraphRewriter:
         new_graph, new_names = rewrite(
             original=graph,
             replacement=self._replacement,
-            interface=self._interface,
             match=match,
             lhs=self._lhs,
             rhs=self._rhs,

--- a/tests/unit_tests/graph/rewrite_test.py
+++ b/tests/unit_tests/graph/rewrite_test.py
@@ -144,7 +144,6 @@ def test_raise_error_if_rewrite_would_produce_dangling_edge():
     raised = False
     try:
         new_graph, new_names = gr.rewrite(
-            interface=gr.BaseGraph().add_node("i0").add_node("i1"),
             replacement=gr.BaseGraph().add_edge("i0", "r").add_edge("r", "i1"),
             original=g,
             match={"i0": "a", "p0": "b", "p1": "c", "i1": "d"},


### PR DESCRIPTION
The interface is already implicitly defined by specifying the left and right hand side mapping from interface nodes to pattern and replacement respectively.
Passing an additional interface graph, would make the API overly complex and add boilerplate code for
building the interface graph.