### PR TITLE
fix(verilog): update verilog templates to correctly replace arrays

### DIFF
--- a/elasticai/creator/ir2verilog/templates.py
+++ b/elasticai/creator/ir2verilog/templates.py
@@ -8,7 +8,7 @@ class _Definition(tpl.TemplateParameter):
     def __init__(self, type: str, name: str, delimiter: str) -> None:
         self.name = name
         self.delimiter = delimiter
-        self.regex = r"(?P<param>{type}\s+(signed\s+)?(\[.*?\]\s+)?{name}\s*=)\s?.[^;,\n]*".format(
+        self.regex = r"(?P<param>{type}\s+(signed\s+)?(\[.*?\]\s+)?{name}\s*=)\s?.([^;,\n]|,(?=.*}}))*".format(
             type=type, name=name
         )
 

--- a/tests/unit_tests/ir2verilog_test.py
+++ b/tests/unit_tests/ir2verilog_test.py
@@ -119,3 +119,12 @@ class TestVerilogTemplate:
             template.substitute({"module_name": "FILTER_FIR_HALF"})
             == "`define FILTER_FIR_HALF_DATA_WIDTH 8\nFILTER_FIR_HALF_DATA_WIDTH + 10"
         )
+
+    def test_can_replace_arrays(self):
+        template = (
+            TemplateDirector()
+            .set_prototype("localparam DATA = {'d2, 'd3};")
+            .localparam("DATA")
+            .build()
+        )
+        assert template.substitute({"DATA": "'d5"}) == "localparam DATA = 'd5;"


### PR DESCRIPTION
closes #612 