### PR TITLE
docs(plugins): name plugin translation stages

### DIFF
--- a/elasticai/creator_plugins/combinatorial/README.md
+++ b/elasticai/creator_plugins/combinatorial/README.md
@@ -1,5 +1,7 @@
 # Combinatorial Plugin
 
+**Translation Stage**: *low level ir* to *vhdl*
+
 **Defined `PluginSymbol`s:**
 
 * `clocked_combinatorial`

--- a/elasticai/creator_plugins/counter/README.md
+++ b/elasticai/creator_plugins/counter/README.md
@@ -1,5 +1,7 @@
 # Counter
 
+**Translation Stage**: *low level ir* to *vhdl*
+
 The plugin provides a counter implemented in vhdl.
 
 :::

--- a/elasticai/creator_plugins/grouped_filter/README.md
+++ b/elasticai/creator_plugins/grouped_filter/README.md
@@ -1,5 +1,8 @@
 # Grouped Filter
 
+**Translation Stage**: *low level ir* to *vhdl*
+
+
 Use this plugin to generate a grouped filter from multiple filter kernels.
 The `grouped_filter` lowering function will consider the filter parameters and the kernels provided in the attribute of an IR node to generate a grouped filter implementation.
 

--- a/elasticai/creator_plugins/lutron/README.md
+++ b/elasticai/creator_plugins/lutron/README.md
@@ -1,5 +1,8 @@
 # Lutron Plugin
 
+**Translation Stage**: *low level ir* to *vhdl*
+
+
 The Lutron plugin provides functionality to generate VHDL code for lookup tables (LUTs). It allows you to define truth tables that map input values to output values.
 
 ## Overview

--- a/elasticai/creator_plugins/padding/README.md
+++ b/elasticai/creator_plugins/padding/README.md
@@ -1,5 +1,7 @@
 # Padding plugin
 
+**Translation Stage**: *low level ir* to *vhdl*
+
 The plugin adds two vhdl hardware designs.
 Both rely completely on combinational logic.
 

--- a/elasticai/creator_plugins/shift_register/README.md
+++ b/elasticai/creator_plugins/shift_register/README.md
@@ -1,5 +1,8 @@
 # Shift Register Plugin
 
+**Translation Stage**: *low level ir* to *vhdl*
+
+
 This plugin implements a shift register in VHDL. 
 The shift register is a digital circuit that can store and shift data.
 The plugin is parameterized by the width of the data points (`WIDTH`) and 

--- a/elasticai/creator_plugins/skeleton/README.md
+++ b/elasticai/creator_plugins/skeleton/README.md
@@ -1,5 +1,8 @@
 # Skeleton
 
+**Translation Stage**: *low level ir* to *vhdl*
+
+
 This skeleton implementation acts as an adapter between the middleware and the new axi-like interfaces for layers.
 It will read the input data from the middleware, store it, feed it to the network, and write the output data back to the middleware.
 Additionally, it takes care of enabling and resetting the network.

--- a/elasticai/creator_plugins/sliding_window/README.md
+++ b/elasticai/creator_plugins/sliding_window/README.md
@@ -1,5 +1,8 @@
 # Sliding Window Plugin
 
+**Translation Stage**: *low level ir* to *vhdl*
+
+
 A VHDL implementation of a sliding window mechanism commonly used in convolutional neural networks and signal processing.
 
 ## Features

--- a/elasticai/creator_plugins/striding_shift_register/README.md
+++ b/elasticai/creator_plugins/striding_shift_register/README.md
@@ -1,5 +1,8 @@
 # Striding Shift Register
 
+**Translation Stage**: *low level ir* to *vhdl*
+
+
 A VHDL implementation of a shift register with configurable stride, useful for implementing strided operations in hardware designs, particularly for neural network architectures.
 
 ## Features

--- a/elasticai/creator_plugins/time_multiplexed_sequential/README.md
+++ b/elasticai/creator_plugins/time_multiplexed_sequential/README.md
@@ -1,12 +1,15 @@
 # Time Multiplexed Sequential
 
+**Translation Stage**: *high level ir* to *low level ir*
+
+
 This plugin creates a time multiplexed sequential model. 
 It supports the following IR graph types:
 
 - `sequential`
 - `network`
 
-and the following node types:
+and the following node types
 
 - `grouped_filter`
 


### PR DESCRIPTION
Not explicitly stating what stage of the
translation process a plugin is meant for
made it hard to put each of them into context.
Adding that information now, to make it
easier to reason about how/when to use each
of the plugins.