### PR TITLE
refactor(graph): publicly expose NodeConstraintFn protocol

### DIFF
--- a/elasticai/creator/graph/__init__.py
+++ b/elasticai/creator/graph/__init__.py
@@ -14,7 +14,7 @@ from .graph_rewriting import (
     rewrite,
 )
 from .name_generation import NameRegistry
-from .subgraph_matching import find_all_subgraphs, find_subgraph
+from .subgraph_matching import NodeConstraintFn, find_all_subgraphs, find_subgraph
 
 __all__ = [
     "BaseGraph",
@@ -31,4 +31,5 @@ __all__ = [
     "RewriteResult",
     "produces_dangling_edge",
     "DanglingEdgeError",
+    "NodeConstraintFn",
 ]


### PR DESCRIPTION
The protocol was introduced to ensure that clients implementing new constraints will use the correct
order for pattern and graph nodes in call signature. This is expected to be a source for errors as both arguments will typically be of the same type.

Hence, the protocol should have been exposed already.