### PR TITLE
docs(plugins): clarify purpose of the plugin system

### DIFF
--- a/docs/creator/plugin-system.md
+++ b/docs/creator/plugin-system.md
@@ -1,8 +1,10 @@
 # Plugin system
 
 The plugin system ([`elasticai.creator.plugin`]()) is
-the way to extend the functionality of the ElasticAI Creator. At its
-core the system is not limited to any specific kind of plugins.
+the way to extend automated lowering passes ([`LoweringPass`]()). At its
+core the system is not limited to any specific target.
+E.g., it can be used to extend the following passes: Ir2Ir, Ir2Verilog, Ir2Torch, Ir2Vhdl, etc.
+
 Currently its main purpose is providing a base for adding new hardware
 components as plugins to the [`Ir2Vdhl`]() translation
 pass.

--- a/elasticai/creator/plugin.py
+++ b/elasticai/creator/plugin.py
@@ -38,7 +38,8 @@ The following table lists these required fields:
   - The name of the plugin, used to identify the plugin
 * - **target platform**
   - `str`
-  - A string describing the target platform for the plugin.
+  - A string describing the target platform for the plugin, ie.
+    the lowering pass it should be loaded into.
     Currently there is no strict definition of the semantics of this string.
 * - **target runtime**
   - `str`


### PR DESCRIPTION
Explicitly state that the plugin system is used
to extend translation passes.