### PR TITLE
fix(graph): fix bug that was preventing matches in some edge cases

### DIFF
--- a/elasticai/creator/graph/vf2/state.py
+++ b/elasticai/creator/graph/vf2/state.py
@@ -99,13 +99,6 @@ class State(Generic[T, TP]):
             if matched_node is not None:
                 yield node, matched_node
 
-    def contains_node_with_lower_id(self, node: T) -> bool:
-        node_id = self.order[node]
-        for other_id, matched_node in enumerate(self.core):
-            if other_id < node_id and matched_node is not None:
-                return True
-        return False
-
     def add_pair(self, a: T, b: TP) -> None:
         self.core[self.order[a]] = b
         self.in_nodes[self.order[a]] = self.current_depth

--- a/tests/unit_tests/graph/vf2/match_test.py
+++ b/tests/unit_tests/graph/vf2/match_test.py
@@ -1,6 +1,10 @@
+from collections.abc import Callable
+
 import pytest
 
 import elasticai.creator.graph as gr
+from elasticai.creator.graph.base_graph import BaseGraph
+from elasticai.creator.graph.graph import Graph
 from elasticai.creator.graph.vf2 import find_all_matches, match
 from elasticai.creator.graph.vf2.matching import MatchError
 
@@ -19,7 +23,7 @@ def add_path(graph: gr.Graph, path: str):
         graph.add_edge(a, b)
 
 
-def test_match_single_edge(create_graph):
+def test_match_single_edge(create_graph: Callable[[], BaseGraph]):
     p = create_graph()
     add_path(p, "a->b")
     g = create_graph()
@@ -27,7 +31,7 @@ def test_match_single_edge(create_graph):
     assert match(p, g) == {"a": "0", "b": "1"}
 
 
-def test_match_single_edge_two_times(create_graph):
+def test_match_single_edge_two_times(create_graph: Callable[[], BaseGraph]):
     p = create_graph()
     add_path(p, "a->b")
     g = create_graph()
@@ -39,7 +43,16 @@ def test_match_single_edge_two_times(create_graph):
     ]
 
 
-def test_double_edge(create_graph):
+def test_graph_matches_itself(create_graph: Callable[[], Graph]):
+    g = create_graph()
+    add_path(g, "1->2")
+    add_path(g, "1->3")
+    print(g.successors)
+
+    match(g, g)
+
+
+def test_double_edge(create_graph: Callable[[], BaseGraph]):
     p = create_graph()
     add_path(p, "a->b->c")
     g = create_graph()
@@ -47,20 +60,19 @@ def test_double_edge(create_graph):
     assert match(p, g) == {"a": "0", "b": "1", "c": "2"}
 
 
-def test_double_out_edge(create_graph):
+def test_double_out_edge(create_graph: Callable[[], BaseGraph]):
     p = create_graph()
     add_path(p, "a->b")
     g = create_graph()
     for path in ["0->1", "0->2"]:
         add_path(g, path)
-
     assert match(p, g) in [
         {"a": "0", "b": "1"},
         {"a": "0", "b": "2"},
     ]
 
 
-def test_donot_match_partially_with_single_edge(create_graph):
+def test_donot_match_partially_with_single_edge(create_graph: Callable[[], BaseGraph]):
     p = create_graph()
     add_path(p, "a->b->c")
     g = create_graph()
@@ -68,7 +80,9 @@ def test_donot_match_partially_with_single_edge(create_graph):
     pytest.raises(MatchError, match, p, g)
 
 
-def test_donot_match_partially_four_to_three_edges(create_graph):
+def test_donot_match_partially_four_to_three_edges(
+    create_graph: Callable[[], BaseGraph],
+):
     p = create_graph()
     add_path(p, "a->b->c->d->e")
     g = create_graph()
@@ -76,7 +90,7 @@ def test_donot_match_partially_four_to_three_edges(create_graph):
     pytest.raises(MatchError, match, p, g)
 
 
-def test_match_acyclic_pattern_to_cyclic_graph(create_graph):
+def test_match_acyclic_pattern_to_cyclic_graph(create_graph: Callable[[], BaseGraph]):
     p = create_graph()
     add_path(p, "a->b")
     g = create_graph()
@@ -85,7 +99,7 @@ def test_match_acyclic_pattern_to_cyclic_graph(create_graph):
     assert find_all_matches(p, g) == []
 
 
-def test_match_cyclic_pattern_to_cyclic_graph(create_graph):
+def test_match_cyclic_pattern_to_cyclic_graph(create_graph: Callable[[], BaseGraph]):
     p = create_graph()
     add_path(p, "a->b->a")
     g = create_graph()
@@ -93,7 +107,7 @@ def test_match_cyclic_pattern_to_cyclic_graph(create_graph):
     assert match(p, g) in [{"a": "0", "b": "1"}, {"a": "1", "b": "0"}]
 
 
-def test_node_constraint_can_prevent_first_match(create_graph):
+def test_node_constraint_can_prevent_first_match(create_graph: Callable[[], BaseGraph]):
     p = create_graph()
     add_path(p, "a->b")
     g = create_graph()
@@ -101,7 +115,7 @@ def test_node_constraint_can_prevent_first_match(create_graph):
     assert match(p, g, lambda pn, gn: gn in ("1", "2")) == {"a": "1", "b": "2"}
 
 
-def test_match_diamond_pattern(create_graph):
+def test_match_diamond_pattern(create_graph: Callable[[], BaseGraph]):
     r"""
     a-b-c-e
      \   /


### PR DESCRIPTION
To prevent exploring duplicate states in the state space representation a total order on nodes was
established. Source of the bug was that this
order was computed over the partial state space
while it should have been computed over the current candidate pairs.