### PR TITLE
fix(ir): improve error message when initializer is not found

### DIFF
--- a/elasticai/creator/ir/rewriting/rewriter.py
+++ b/elasticai/creator/ir/rewriting/rewriter.py
@@ -189,7 +189,12 @@ class Rewriter:
         for ctx in contexts:
             for node_name in ctx.replacement.nodes:
                 if node_name not in rule.interface:
-                    initialize = rule.replacement.nodes[node_name].attributes["init"]
+                    try:
+                        initialize = rule.replacement.nodes[node_name].data["init"]
+                    except KeyError:
+                        raise ValueError(
+                            f"Node {node_name} in replacement does not have an initializer."
+                        )
                     node = ctx.replacement.nodes[node_name]
                     node.data.update(initialize(ctx.match))
 


### PR DESCRIPTION
If a user does not specify an init routine for a replacement node the rewriter would just fail with a KeyError not mentioning the nodes name. This turns the error into a ValueError and communicates the node name in the message. This way, users can ensure to provide
an init routine for the mentioned node.