### PR TITLE
fix(graph): fix bug where available names would be skipped

### DIFF
--- a/elasticai/creator/graph/name_generation.py
+++ b/elasticai/creator/graph/name_generation.py
@@ -5,15 +5,18 @@ class NameRegistry:
     def __init__(self):
         self._registry = {}
 
+    def _get_name_count(self, name):
+        return self._registry.get(name, 0)
+
     def prepopulate(self, names):
         for name in names:
             match = re.match(r"(.+)_(\d+)$", name)
+            suffix = 0
             if match:
                 name = match.group(1)
                 suffix = int(match.group(2))
-            else:
-                suffix = 0
-            self._registry[name] = self._registry.get(name, suffix) + 1
+            suffix = max(suffix, self._get_name_count(name))
+            self._registry[name] = suffix
         return self
 
     def get_unique_name(self, name):
@@ -21,6 +24,6 @@ class NameRegistry:
             self._registry[name] = 0
             return name
 
-        new_name = f"{name}_{self._registry[name]}"
+        new_name = f"{name}_{self._registry[name] + 1}"
         self._registry[name] += 1
         return new_name

--- a/tests/unit_tests/graph/dangling_edges_test.py
+++ b/tests/unit_tests/graph/dangling_edges_test.py
@@ -99,3 +99,41 @@ def test_do_not_remove_second_match_if_overlap_only_occurs_in_interface():
             lhs.values(),
         )
     )
+
+
+def test_pattern_seq_with_2_interface_nodes():
+    g = build_graph(
+        {
+            "a": ["b"],
+            "b": ["c"],
+            "c": ["d"],
+            "d": ["e"],
+            "e": ["f"],
+            "f": ["g"],
+            "g": ["h"],
+        }
+    )
+    p = build_graph(
+        {
+            "0": ["1"],
+            "1": ["2"],
+            "2": ["3"],
+            "3": ["4"],
+        }
+    )
+    matches = gr.find_all_subgraphs(
+        pattern=p, graph=g, node_constraint=lambda _, __: True
+    )
+    lhs = {"i0": "0", "i1": "1", "i2": "3", "i3": "4"}
+    expected_leftover_matches = []
+    for sequence in [("a", "b", "c", "d", "e"), ("d", "e", "f", "g", "h")]:
+        expected_leftover_matches.append(
+            {f"{i}": node for i, node in enumerate(sequence)}
+        )
+    assert expected_leftover_matches == list(
+        gr.get_rewriteable_matches(
+            g,
+            matches,
+            lhs.values(),
+        )
+    )

--- a/tests/unit_tests/ir/name_generation_test.py
+++ b/tests/unit_tests/ir/name_generation_test.py
@@ -29,4 +29,11 @@ def test_start_counting_from_highest_suffix():
 def test_count_either_no_suffix_or_zero_as_one():
     reg = NameRegistry()
     reg.prepopulate(["a", "a_0"])
-    assert reg.get_unique_name("a") == "a_2"
+    assert reg.get_unique_name("a") == "a_1"
+
+
+def test_use_maximum_of_suffixes():
+    reg = NameRegistry()
+    reg.prepopulate(["a", "a_3", "a_2"])
+
+    assert reg.get_unique_name("a") == "a_4"


### PR DESCRIPTION
The rewriting algorithm will automatically genereate new names for
inserted nodes, to ensure node names are kept unique. In some cases
the algorithm would skip suffix indices, e.g., conv1d_1, conv1d_3
instead of conv1d_1, conv1d_2.
This should now be fixed.

