### PR TITLE
fix(ir): remove problematic matches before rewriting

### DIFF
--- a/elasticai/creator/ir/rewriting/rewriter.py
+++ b/elasticai/creator/ir/rewriting/rewriter.py
@@ -2,7 +2,13 @@ import copy
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from typing import Any, Generic, Self, TypeVar, overload
 
-from elasticai.creator.graph import Graph, NodeConstraintFn, find_all_subgraphs, rewrite
+from elasticai.creator.graph import (
+    Graph,
+    NodeConstraintFn,
+    find_all_subgraphs,
+    get_rewriteable_matches,
+    rewrite,
+)
 from elasticai.creator.ir.base.attribute import Attribute
 
 from ..core import Edge, Implementation, Node
@@ -188,12 +194,15 @@ class Rewriter:
         self._current_rule = rule
         self._current_impl = impl
         self._current_contexts = []
-        matches = find_all_subgraphs(
+        matches: Iterable[dict[str, str]] = find_all_subgraphs(
             graph=impl.graph,
             pattern=rule.pattern.graph,
             node_constraint=self._lift_constraint_fn(
                 fn=rule.node_constraint, impl=impl, pattern=rule.pattern
             ),
+        )
+        matches = get_rewriteable_matches(
+            matches=matches, original=impl.graph, interface_nodes=rule.interface
         )
         self._prepare_contexts(matches)
         rewritten = self._rewrite_raw_graphs()


### PR DESCRIPTION
The rewrite algorithm found all possible matches
and would then edit the corresponding subgraphs.
However, this method would edit nodes that might
have been removed/edited already.
The graph module provides methods to filter
matches to obtain only non-overlapping matches
that are safe for rewrite.
The ir.rewrite module now uses that function
before applying the rewrite rules to matches.