### PR TITLE
update and fix ci

### DIFF
--- a/.github/actions/prepare-devenv/action.yml
+++ b/.github/actions/prepare-devenv/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: cachix/cachix-action@v15
       with:
         name: devenv
-    - run: nix profile install nixpkgs/f0295845e58ada369322524631821b01c0db13a7#devenv
+    - run: nix profile install nixpkgs/nixos-25.05#devenv
       shell: bash
     - run: devenv shell
       shell: bash

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,7 @@ jobs:
       - name: prepare devenv
         uses: ./.github/actions/prepare-devenv
       - name: run python linting
-        run: devenv shell devenv tasks run check:code-lint
+        run: devenv shell devenv tasks run check:code-lint --mode before
 
   check-commit-lint:
     name: Lint Commits
@@ -35,7 +35,7 @@ jobs:
       - name: prepare devenv
         uses: ./.github/actions/prepare-devenv
       - name: run commit linting
-        run: devenv shell devenv tasks run check:commit-lint
+        run: devenv shell devenv tasks run check:commit-lint --mode before
 
   check-package-build:
     name: Check that package builds
@@ -49,7 +49,7 @@ jobs:
         uses: ./.github/actions/prepare-devenv
 
       - name: run build check
-        run: devenv shell devenv tasks run package:build
+        run: devenv shell devenv tasks run package:build --mode before
 
   check-docs-build:
     name: check that docs build
@@ -67,7 +67,7 @@ jobs:
       - name: run docs build check
         shell: devenv shell bash -- -e {0}
         run: |
-          devenv tasks run docs:single-page
+          devenv tasks run docs:single-page --mode before
           nix run nixpkgs#monolith -- build/docs/index.html > build/docs/single_page.html
       - name: Upload docs preview
         uses: actions/upload-artifact@v4
@@ -98,7 +98,7 @@ jobs:
       - name: prepare devenv
         uses: ./.github/actions/prepare-devenv
       - name: run tests
-        run: devenv shell devenv tasks run check:tests
+        run: devenv shell devenv tasks run check:tests --mode before
       - name: Publish coverage report
         uses: orgoro/coverage@v3.1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
         run: nix profile install nixpkgs#devenv
       - name: build docs
         shell: devenv shell -- bash -e {0}
-        run: devenv tasks run "docs:build"
+        run: devenv tasks run "docs:build" --mode before
 
       - name: Upload Artifacts
         uses: actions/upload-pages-artifact@v3

--- a/devenv.lock
+++ b/devenv.lock
@@ -102,6 +102,21 @@
         "type": "github"
       }
     },
+    "nixpkgs-24-11": {
+      "locked": {
+        "lastModified": 1751290243,
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-python": {
       "inputs": {
         "flake-compat": "flake-compat_2",
@@ -142,6 +157,7 @@
         "devenv": "devenv",
         "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-24-11": "nixpkgs-24-11",
         "nixpkgs-python": "nixpkgs-python",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "pre-commit-hooks": [

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1739444039,
+        "lastModified": 1755039979,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "1235cd13f47df6ad19c8a183c6eabc1facb7c399",
+        "rev": "63db0a32cd767c2a9089fbaf24b0bb91c64c0652",
         "type": "github"
       },
       "original": {
@@ -19,10 +19,10 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1733328505,
+        "lastModified": 1747046372,
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -34,10 +34,10 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1733328505,
+        "lastModified": 1747046372,
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -55,10 +55,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1737465171,
+        "lastModified": 1754416808,
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
+        "rev": "9c52372878df6911f9afc1e2a1391f55e4dfc864",
         "type": "github"
       },
       "original": {
@@ -89,10 +89,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733477122,
+        "lastModified": 1754299112,
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "7bd9e84d0452f6d2e63b6e6da29fe73fac951857",
+        "rev": "16c21c9f5c6fb978466e91182a248dd8ca1112ac",
         "type": "github"
       },
       "original": {
@@ -110,10 +110,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1733319315,
+        "lastModified": 1754518819,
         "owner": "cachix",
         "repo": "nixpkgs-python",
-        "rev": "01263eeb28c09f143d59cd6b0b7c4cc8478efd48",
+        "rev": "4253cbbd2b36ec8021962726c95ebdf874fd26af",
         "type": "github"
       },
       "original": {
@@ -124,10 +124,10 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1739451785,
+        "lastModified": 1755020227,
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1128e89fd5e11bb25aedbfc287733c6502202ea9",
+        "rev": "695d5db1b8b20b73292501683a524e0bd79074fb",
         "type": "github"
       },
       "original": {

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -8,5 +8,7 @@ inputs:
         follows: nixpkgs
   nixpkgs-unstable:
     url: github:nixos/nixpkgs/nixpkgs-unstable
+  nixpkgs-24-11:
+    url: github:nixos/nixpkgs/release-24.11
 imports:
   - ./devenv_modules/ghdl/

--- a/devenv_modules/ghdl/devenv.nix
+++ b/devenv_modules/ghdl/devenv.nix
@@ -17,11 +17,14 @@
   config,
   ...
 }: let
-  unstablePkgs = import inputs.nixpkgs-unstable {system = pkgs.stdenv.system;};
+  # choose 24.11 release for ghdl as later releases are broken due to gnat-{13, 14}
+  # not building for x86_64-darwin
+  # see https://github.com/NixOS/nixpkgs/issues/385174
+  pkgsForGhdl = import inputs.nixpkgs-24-11 {system = pkgs.stdenv.system;};
   rosettaPkgs =
-    if unstablePkgs.stdenv.isDarwin && unstablePkgs.stdenv.isAarch64
-    then unstablePkgs.pkgsx86_64Darwin
-    else unstablePkgs;
+    if pkgsForGhdl.stdenv.isDarwin && pkgsForGhdl.stdenv.isAarch64
+    then pkgsForGhdl.pkgsx86_64Darwin
+    else pkgsForGhdl;
 in {
   options = {
     languages.vhdl = {

--- a/elasticai/creator/ir_transforms/reorder.py
+++ b/elasticai/creator/ir_transforms/reorder.py
@@ -16,7 +16,7 @@ def build_sequential_pattern(
     for node in sequence:
         pattern.add_node(node)
         if previous is not None:
-            pattern.add_edge(src=previous, dst=node.name)
+            pattern.add_edge(src=previous, dst=node.name, data={})
         previous = node.name
 
     return pattern

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,8 +161,7 @@ exclude = [
 line-length = 88
 indent-width = 4
 
-# Assume Python 3.8
-target-version = "py38"
+target-version = "py311"
 
 [tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.

--- a/tests/system_tests/conv1d/conv1d.py
+++ b/tests/system_tests/conv1d/conv1d.py
@@ -1,8 +1,8 @@
 import subprocess
+import tomllib
 from pathlib import Path
 
 import serial
-import tomllib
 import torch
 
 from elasticai.creator.file_generation.on_disk_path import OnDiskPath

--- a/tests/system_tests/linear_layer/linear_layer.py
+++ b/tests/system_tests/linear_layer/linear_layer.py
@@ -1,10 +1,10 @@
 import subprocess
 import time
+import tomllib
 from pathlib import Path
 
 import numpy as np
 import serial  # type: ignore
-import tomllib
 import torch
 
 from elasticai.creator.file_generation.on_disk_path import OnDiskPath


### PR DESCRIPTION
Points devenv to current release on nixos-25.05 branch.
Currently this is devenv 1.8.1.

Also, we apply the new --mode flag to use the
tasks in a `make` like fashion as we did before.
(The behaviour for executing tasks was changed in 1.7)

And we apply minor changes to ruff setup to make
newer python syntax pass, e.g. match case statements.

- **chore(gh-actions): update devenv version for ci to point to nixos-25.05**
- **style: reorder imports**
- **fix(devenv): pin ghdl to version from nixpkgs-24.11**
- **chore(gh-actions): call devenv with --mode before flag to execute deps**
- **chore(pyproject): use py311 for ruff checks**
