### PR TITLE
chore(gh): allow blank github issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Documentation
     url: https://es-ude.github.io/elastic-ai.creator/


### PR DESCRIPTION
Templates were often too restrictive and currently
there is a lack of time to setup better ones.
