### PR TITLE
fix(ir2torch): fix argument passing for torch fx nodes

### DIFF
--- a/elasticai/creator/torch2ir/torch2ir.py
+++ b/elasticai/creator/torch2ir/torch2ir.py
@@ -114,10 +114,10 @@ class Torch2Ir:
         impl = ir_node.implementation
         if impl not in self._registry and impl not in ("input", "output"):
             self._registry[impl] = Implementation(
+                name=impl,
+                type=ir_node.type,
                 graph=BaseGraph(),
-                data=dict(
-                    name=impl, type=ir_node.type, **self._extract_attributes(node)
-                ),
+                data=dict(**self._extract_attributes(node)),
             )
 
         for successor in self._get_successors(node):

--- a/tests/unit_tests/ir2torch_test.py
+++ b/tests/unit_tests/ir2torch_test.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 import hypothesis.strategies as st
+import torch
 from hypothesis import given
 from torch.nn import Linear, ReLU, Sequential
 
@@ -64,3 +65,11 @@ def test_create_parent_modules_for_implemantations_with_dots():
     original_params = to_native_python(original.named_parameters())
     rebuilt_params = to_native_python(rebuilt.named_parameters())
     assert original_params == rebuilt_params
+
+
+def test_perform_inference():
+    original = model()
+    ir = convert(original)
+    rebuilt = ir2torch_converter().convert(ir)
+    print(rebuilt.graph)
+    rebuilt(torch.randn((1, 1)))


### PR DESCRIPTION
Misunderstood torch fx api. To make nodes depend
on other nodes, we have to pass the node objects
instead of just their names.
Using the names, will result in the executed
code calling the targets with strings.
