### PR TITLE
fix(clocked_combinatorial): do not call iter_bfs_down on implementation

### DIFF
--- a/tach.toml
+++ b/tach.toml
@@ -151,7 +151,7 @@ depends_on = ["elasticai.creator.ir2vhdl"]
 
 [[modules]]
 path = "elasticai.creator_plugins.combinatorial"
-depends_on = ["elasticai.creator.ir2vhdl"]
+depends_on = ["elasticai.creator.ir2vhdl", "elasticai.creator.graph"]
 
 [[modules]]
 path = "elasticai.creator_plugins.grouped_filter"


### PR DESCRIPTION
The corresponding method was previously removed.
