### PR TITLE
fix(hw_function_id): do not use relative path to identify file with id

### DIFF
--- a/elasticai/creator/hw_function_id.py
+++ b/elasticai/creator/hw_function_id.py
@@ -11,7 +11,7 @@ class HwFunctionIdUpdater:
         target_file: str | Path,
         replace_id_fn: Callable[[Iterable[str], bytes], Iterator[str]],
     ):
-        self._target_file = Path(target_file).relative_to(build_dir)
+        self._target_file = Path(target_file)
         self._build_dir = build_dir
         self._id = bytes()
         self._replace_id_fn = replace_id_fn


### PR DESCRIPTION
Previous solution would try strip away a given build
folder from the file containing the id. This happened
due to a misinterpretation of what `Path.relative_to`
actually does. 
