### PR TITLE
fix(ir2vhdl): use correct width for Shape

### DIFF
--- a/elasticai/creator/ir2vhdl/ir2vhdl.py
+++ b/elasticai/creator/ir2vhdl/ir2vhdl.py
@@ -86,7 +86,9 @@ class Shape:
 
     @property
     def depth(self) -> int:
-        return self._data[0]
+        if len(self._data) > 1:
+            return self._data[0]
+        return 1
 
     def __eq__(self, other):
         if isinstance(other, tuple):
@@ -101,7 +103,7 @@ class Shape:
         if len(self._data) > 1:
             return self._data[1]
         else:
-            return 1
+            return self._data[0]
 
     @property
     def height(self) -> int:

--- a/elasticai/creator_plugins/combinatorial/vhdl_nodes/shift_register.py
+++ b/elasticai/creator_plugins/combinatorial/vhdl_nodes/shift_register.py
@@ -1,7 +1,11 @@
+import warnings
+
 from elasticai.creator.ir2vhdl import Instance, VhdlNode
 
 from .clocked_combinatorial import ClockedInstance
-from .node_factory import InstanceFactoryForCombinatorial
+from .node_factory import (
+    InstanceFactoryForCombinatorial,
+)
 
 
 @InstanceFactoryForCombinatorial.register
@@ -9,10 +13,28 @@ def shift_register(node: VhdlNode) -> Instance:
     return ShiftRegister(node)
 
 
+def _check_input_output_shape_compatibility(node):
+    input_shape, output_shape = node.input_shape, node.output_shape
+    if output_shape.size() % input_shape.size() != 0:
+        raise ValueError(
+            "Found incompatible input output shapes for shift_register. Total output size has to be an integer multiple of total input size, but found output={output} and input={input}.".format(
+                output=output_shape, input=input_shape
+            )
+        )
+    if output_shape.depth != input_shape.depth:
+        warnings.warn(
+            'Detected mismatching input output shapes for shift_register for node "{}". Width of output and input shape should usually be equal, but found output={} and input={}.'.format(
+                node.name, output_shape, input_shape
+            ),
+            stacklevel=3,
+        )
+
+
 class ShiftRegister(ClockedInstance):
     _logic_signals_with_default_suffix = ("valid_in", "valid_out")
 
     def __init__(self, node: VhdlNode):
+        _check_input_output_shape_compatibility(node)
         data_width = node.input_shape.size()
         num_points = node.output_shape.width
         output_width = node.output_shape.size()

--- a/elasticai/creator_plugins/combinatorial/vhdl_nodes/sliding_window.py
+++ b/elasticai/creator_plugins/combinatorial/vhdl_nodes/sliding_window.py
@@ -1,12 +1,34 @@
+import warnings
+
 from elasticai.creator.ir2vhdl import VhdlNode
 
 from .clocked_combinatorial import ClockedInstance
-from .node_factory import InstanceFactoryForCombinatorial
+from .node_factory import (
+    InstanceFactoryForCombinatorial,
+)
 
 
 @InstanceFactoryForCombinatorial.register
 def sliding_window(node):
     return SlidingWindowNode(node)
+
+
+def _check_input_output_shape_compatibility(node):
+    input_shape = node.input_shape
+    output_shape = node.output_shape
+    if input_shape.size() % output_shape.size() != 0:
+        raise ValueError(
+            "Found incompatible input output shapes for sliding_window. Total input size has to be an integer multiple of total output size, but found output={output} and input={input}.".format(
+                output=output_shape, input=input_shape
+            )
+        )
+    if output_shape.depth != input_shape.depth:
+        warnings.warn(
+            'Detected mismatching input output shapes for sliding_window for node "{}". Depth of output and input shape should usually be equal, but found output={} and input={}.'.format(
+                node.name, output_shape, input_shape
+            ),
+            stacklevel=3,
+        )
 
 
 class SlidingWindowNode(ClockedInstance):
@@ -16,8 +38,9 @@ class SlidingWindowNode(ClockedInstance):
         self,
         node: VhdlNode,
     ):
-        data_width = node.input_shape.depth
-        num_points = node.output_shape.depth
+        _check_input_output_shape_compatibility(node)
+        data_width = node.input_shape.size()
+        num_points = node.output_shape.size()
         if (
             "generic_map" in node.attributes  #  pyright: ignore
             and "stride" in node.attributes["generic_map"]  #  pyright: ignore

--- a/elasticai/creator_plugins/combinatorial/vhdl_nodes/striding_shift_register.py
+++ b/elasticai/creator_plugins/combinatorial/vhdl_nodes/striding_shift_register.py
@@ -1,6 +1,8 @@
 from elasticai.creator.ir2vhdl import VhdlNode
 
-from .node_factory import InstanceFactoryForCombinatorial
+from .node_factory import (
+    InstanceFactoryForCombinatorial,
+)
 from .shift_register import ShiftRegister
 
 


### PR DESCRIPTION
Implementation would previously incorrectly return
depth instead of width (and set width to 1)
in cases where only width was specified
