### PR TITLE
fix(sliding_window): derive stride for hw design correctly

### DIFF
--- a/elasticai/creator_plugins/combinatorial/tests/test_vhdl_nodes.py
+++ b/elasticai/creator_plugins/combinatorial/tests/test_vhdl_nodes.py
@@ -152,7 +152,7 @@ class TestSlidingWindow:
         expected = (
             "a: entity work.impl(rtl)",
             "generic map (",
-            "STRIDE => 2,",
+            "STRIDE => 8,",
             "INPUT_WIDTH => 8,",
             "OUTPUT_WIDTH => 4",
             ")",

--- a/elasticai/creator_plugins/combinatorial/vhdl_nodes/sliding_window.py
+++ b/elasticai/creator_plugins/combinatorial/vhdl_nodes/sliding_window.py
@@ -48,6 +48,8 @@ class SlidingWindowNode(ClockedInstance):
             stride = node.attributes["generic_map"]["stride"]  # pyright: ignore
         else:
             stride = node.attributes["stride"]  # pyright: ignore
+
+        stride = stride * node.output_shape.depth
         super().__init__(
             node,
             input_width=data_width,


### PR DESCRIPTION
The hw design for the sliding window refers to stride in bits,
opposed to the shift registers that refer to stride by input length.
