### PR TITLE
fix(grouped_filters): raise error if `groups != len(kernels_per_group)`

### DIFF
--- a/elasticai/creator_plugins/grouped_filter/src/filter.py
+++ b/elasticai/creator_plugins/grouped_filter/src/filter.py
@@ -75,6 +75,12 @@ def grouped_filter(impl: Implementation) -> Implementation:
         )
     )
     kernels = impl.attributes["kernel_per_group"]
+    if len(kernels) != params.groups:
+        raise ValueError(
+            "number of kernels per group should match the number of groups but found {}  and {}".format(
+                len(kernels), params.groups
+            )
+        )
     g = GroupedFilterIndexGenerator(
         params=FilterParameters(
             kernel_size=params.kernel_size,


### PR DESCRIPTION
These two parameters becoming out of sync is always a programming
mistake by the client and leads to errors that might become
apparent only during synthesis, thus we raise an error here already.
