### PR TITLE
wip: NEEDS TEST fix(time_mult_seq): remember last filter params correctly

### DIFF
--- a/elasticai/creator_plugins/time_multiplexed_sequential/src/__init__.py
+++ b/elasticai/creator_plugins/time_multiplexed_sequential/src/__init__.py
@@ -81,6 +81,7 @@ class _Sequential:
             type="clocked_combinatorial",
         )
         self._last_node: Node | None = None
+        self._last_filter_parameters: None | FilterParameters = None
         self._counting_node_constructor = append_counter_suffix_before_construction(
             vhdl_node
         )
@@ -126,9 +127,7 @@ class _Sequential:
                 }
             )
         if self._need_shift_register(params):
-            old_params = _FilterNode(
-                self._last_node.name, self._last_node.data
-            ).filter_parameters
+            old_params = self._last_filter_parameters
             self.strided_shift_register(
                 output_shape=(
                     params.in_channels,
@@ -184,6 +183,31 @@ class _Sequential:
         )
         self._impl.add_node(new_node)
         self._last_node = new_node
+        if (
+            "filter_parameters" in new_node.data
+            and self._last_filter_parameters is not None
+        ):
+            params = _FilterNode(new_node.name, new_node.data).filter_parameters
+
+            if params.kernel_size == 1:
+                self._last_filter_parameters = FilterParameters(
+                    kernel_size=params.kernel_size,
+                    in_channels=params.in_channels,
+                    out_channels=params.out_channels,
+                    groups=params.groups,
+                    stride=self._last_filter_parameters.stride * params.stride,
+                    input_size=params.input_size,
+                    output_size=params.output_size,
+                )
+            else:
+                self._last_filter_parameters = params
+        elif self._last_filter_parameters is None:
+            self._last_filter_parameters = FilterParameters(
+                kernel_size=1,
+                in_channels=new_node.input_shape.depth,
+                out_channels=new_node.output_shape.depth,
+            )
+
         if old_node is not None:
             self._impl.add_edge(
                 edge(


### PR DESCRIPTION
Previously the algorithm would forget the last filter parameter.
Layers with kernel size 1 do not need a shift register in front of
them and the algorithm was only remembering the last encountered
node. Thus, after encountering a layer l with kernel size 1
after a layer (l-1) with a stride > 1 we would forget about the
stride as layer l had stride=1. Now we remember the stride until
we instantiate a striding shift register.
