### PR TITLE
fix(time_mult_seq): remember last filter params correctly

### DIFF
--- a/elasticai/creator_plugins/time_multiplexed_sequential/tests/test_lower.py
+++ b/elasticai/creator_plugins/time_multiplexed_sequential/tests/test_lower.py
@@ -1,6 +1,13 @@
 import pytest
 
-from elasticai.creator.ir2vhdl import LoweringPass, Shape, edge, vhdl_node
+from elasticai.creator.ir2vhdl import (
+    Implementation,
+    LoweringPass,
+    Shape,
+    edge,
+    vhdl_node,
+)
+from elasticai.creator_plugins.grouped_filter import FilterParameters
 from elasticai.creator_plugins.time_multiplexed_sequential.src import (
     network as _network_handler,
 )
@@ -120,3 +127,74 @@ def test_add_correct_edges(lower):
         edge(src="conv1_i0", dst="output", src_dst_indices=tuple()),
     )
     assert edges == expected
+
+
+def test_remember_stride_after_pointwise_filter() -> None:
+    in_channels = 1
+    input_shape = Shape(in_channels, 20)
+
+    net = Implementation(name="network", type="network")
+    net.add_nodes(
+        (
+            vhdl_node(
+                name="input",
+                input_shape=input_shape,
+                output_shape=input_shape,
+                type="input",
+                implementation="",
+            ),
+            vhdl_node(
+                name="f0_i0",
+                type="filter",
+                implementation="f0",
+                input_shape=(1, 20),
+                output_shape=(2, 10),
+                attributes=dict(
+                    filter_parameters=FilterParameters(
+                        kernel_size=2, in_channels=1, out_channels=2, stride=2
+                    ).as_dict()
+                ),
+            ),
+            vhdl_node(
+                name="f1_i0",
+                type="filter",
+                implementation="f1",
+                input_shape=(2, 10),
+                output_shape=(3, 10),
+                attributes=dict(
+                    filter_parameters=FilterParameters(
+                        kernel_size=1, out_channels=3, in_channels=2
+                    ).as_dict()
+                ),
+            ),
+            vhdl_node(
+                name="f2_i0",
+                type="filter",
+                implementation="f2",
+                input_shape=(3, 10),
+                output_shape=(2, 9),
+                attributes=dict(
+                    filter_parameters=FilterParameters(
+                        kernel_size=2, out_channels=2, in_channels=3
+                    ).as_dict()
+                ),
+            ),
+            vhdl_node(
+                name="output",
+                type="output",
+                implementation="",
+                input_shape=(2, 9),
+                output_shape=(2, 9),
+            ),
+        )
+    )
+    edge_sequence = ["input", "f0_i0", "f1_i0", "f2_i0", "output"]
+    net.add_edges(
+        (
+            edge(src, dst, tuple())
+            for src, dst in zip(edge_sequence[:-1], edge_sequence[1:])
+        )
+    )
+    lowered = sequential(net)
+    follower_of_pointwise = list(lowered.successors("f1_i0").values())[0]
+    assert follower_of_pointwise.type == "striding_shift_register"

--- a/elasticai/creator_plugins/time_multiplexed_sequential/tests/test_lower_fn_with_sliding_window_input.py
+++ b/elasticai/creator_plugins/time_multiplexed_sequential/tests/test_lower_fn_with_sliding_window_input.py
@@ -50,7 +50,8 @@ def test_inserts_striding_shift_register():
         type=type,
         attributes={"generic_map": {"stride": 2}},
     ).data
-
+    for n in lowered.nodes.values():
+        print(n)
     assert lowered.nodes[name].data == expected
 
 


### PR DESCRIPTION
Previously the algorithm would forget the last filter parameter.
Layers with kernel size 1 do not need a shift register in front of
them and the algorithm was only remembering the last encountered
node. Thus, after encountering a layer l with kernel size 1
after a layer (l-1) with a stride > 1 we would forget about the
stride as layer l had stride=1. Now we remember the stride until
we instantiate a striding shift register.
