### PR TITLE
feat(cocotb): use hash for generating test data paths based on lists etc

### DIFF
--- a/tests/unit_tests/testing/cocotb_pytest_test.py
+++ b/tests/unit_tests/testing/cocotb_pytest_test.py
@@ -23,9 +23,28 @@ def test_create_name_function_with_args():
     assert actual == expected
 
 
+def test_create_name_for_function_with_list_args():
+    actual = create_name_for_build_test_subdir(
+        function_with_args, [1, 2, 3], 2, c="abcd"
+    )
+    h = hash((1, 2, 3)).to_bytes(length=8, signed=True).hex()
+    expected = f"function_with_args_a_{h}_b_2_c_abcd"
+    assert actual == expected
+
+
+def test_create_name_for_fn_with_dict_args():
+    actual = create_name_for_build_test_subdir(
+        function_with_args, {"a": 1}, 2, c="abcd"
+    )
+    h = hash((("a", 1),)).to_bytes(length=8, signed=True).hex()
+    expected = f"function_with_args_a_{h}_b_2_c_abcd"
+    assert actual == expected
+
+
 @pytest.fixture
 def dummy_fixture_fn(request):
     def run(local_namespace):
+        print(request.node.callspec)
         namespace_without_fixture = {
             k: v for k, v in local_namespace.items() if k != "dummy_fixture_fn"
         }
@@ -36,7 +55,7 @@ def dummy_fixture_fn(request):
     return run
 
 
-@pytest.mark.parametrize("x", [4, 2])
+@pytest.mark.parametrize("x", [4])
 def test_pass_parameter_to_fixture(dummy_fixture_fn, x):
     actual = dummy_fixture_fn(locals())
     expected = f"test_pass_parameter_to_fixture_x_{x}"


### PR DESCRIPTION
When parametrizing cocotb test runners with arguments that are
non primitive, we want to avoid super long folder names, hence
we use hashes to encode list and dict like argument values.
