### PR TITLE
chore(secrets): add secretspec

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -19,6 +19,7 @@ in {
     pkgs.jujutsu
     pkgs.graphviz
     pkgs.cocogitto
+    pkgs.secretspec
     pkgs.alejandra # nix formatter
     pkgs.zlib # needed as dependency cocotb/ghdl under circumstances
     pkgs.iverilog

--- a/secretspec.toml
+++ b/secretspec.toml
@@ -1,0 +1,17 @@
+[project]
+name = "elasticai-new-creator"
+revision = "1.0"
+# Extend configurations from subdirectories
+# extends = [ "subdir1", "subdir2" ]
+
+[profiles.default]
+SYNTH_HOST = { description = "SYNTH_HOST secret", required = true }
+# DATABASE_URL = { description = "Database connection string", required = true }
+
+[profiles.development]
+# Development profile inherits all secrets from default profile
+# Only define secrets here that need different values or settings than default
+# DATABASE_URL = { default = "sqlite:///dev.db" }
+#
+# New secrets
+# REDIS_URL = { description = "Redis connection URL for caching", required = false, default = "redis://localhost:6379" }


### PR DESCRIPTION
The secretspec tool allows to load secrets
from keyrings to avoid them being accidentally
committed.
