### PR TITLE
chore(devenv): add scripts for running local checks and fixes

### DIFF
--- a/.github/actions/prepare-devenv/action.yml
+++ b/.github/actions/prepare-devenv/action.yml
@@ -3,8 +3,8 @@ description: "Prepare the development environment using devenv shell"
 runs:
   using: "composite"
   steps:
-    - uses: cachix/install-nix-action@v25
-    - uses: cachix/cachix-action@v15
+    - uses: cachix/install-nix-action@v31
+    - uses: cachix/cachix-action@v17
       with:
         name: devenv
     - run: nix profile install nixpkgs/nixos-25.11#devenv

--- a/.github/actions/prepare-devenv/action.yml
+++ b/.github/actions/prepare-devenv/action.yml
@@ -7,5 +7,5 @@ runs:
     - uses: cachix/cachix-action@v17
       with:
         name: devenv
-    - run: nix profile install nixpkgs/nixos-25.11#devenv
+    - run: nix profile install nixpkgs/nixos-unstable#devenv
       shell: bash

--- a/devenv.nix
+++ b/devenv.nix
@@ -67,6 +67,15 @@ in {
       description = ''        Run hw tests depending on the experiment framework. This uses a different import mode to resolve
               import issues. IMPORTANT: this is only temporary and will be solved more naturally in the future'';
     };
+    run_all_fast_checks = {
+      exec = ''devenv tasks run check:local --mode before'';
+    };
+    fix_all = {
+      exec = ''
+        uv run ruff check --fix
+        ${pkgs.alejandra}/bin/alejandra --exclude ./.devenv --exclude ./.devenv.flake.nix .
+      '';
+    };
   };
 
   tasks = let
@@ -97,10 +106,10 @@ in {
 
     "check:commit-lint" = {
       exec = ''
-        if $CI; then
+        if [ -n "$CI" ]; then
           ${pkgs.cocogitto}/bin/cog check ..$GITHUB_SOURCE_REF
         else
-          ${pkgs.cocogitto}/bin/cog check --from-latest-tag --ignore-merge-commits
+          ${pkgs.cocogitto}/bin/cog check main..
         fi
       '';
     };
@@ -146,9 +155,29 @@ in {
     };
 
     "check:code-lint" = {
+      after = [
+        "check:nix-lint"
+        "check:architecture"
+        "check:python-lint"
+        "check:types"
+      ];
     };
 
     "check:tests" = {
+      after = [
+        "check:slow-tests"
+        "check:fast-tests"
+      ];
+    };
+
+    "check:local" = {
+      after = [
+        "check:commit-lint"
+        "check:nix-lint"
+        "check:architecture"
+        "check:python-lint"
+        "check:fast-tests"
+      ];
     };
   };
 }


### PR DESCRIPTION
Devs can now run

- `run_all_fast_checks`: fast tests and linting
- `fix_all`: fix autofixable problems, e.g., linting
