### PR TITLE
chore(ci): use devenv from nixos unstable

### DIFF
--- a/.github/actions/prepare-devenv/action.yml
+++ b/.github/actions/prepare-devenv/action.yml
@@ -7,5 +7,5 @@ runs:
     - uses: cachix/cachix-action@v17
       with:
         name: devenv
-    - run: nix profile install nixpkgs/nixos-25.11#devenv
+    - run: nix profile install nixpkgs/nixos-unstable#devenv
       shell: bash


### PR DESCRIPTION
We need more up to date devenv builds
