### PR TITLE
refactor(nn.sequential): introduce shared SequentialDesignBuilder

### DIFF
--- a/elasticai/creator/nn/sequential/design_builder.py
+++ b/elasticai/creator/nn/sequential/design_builder.py
@@ -1,0 +1,55 @@
+from collections.abc import Iterator, Sequence
+from typing import Protocol
+
+from elasticai.creator.vhdl.design.design import Design
+
+
+class SequentialSubmodule(Protocol):
+    def create_design(self, name: str) -> Design: ...
+
+
+class SequentialDesignFactory(Protocol):
+    def create_sequential_design(
+        self, sub_designs: list[Design], name: str
+    ) -> Design: ...
+
+
+class SequentialDesignBuilder:
+    def __init__(self, design_factory: SequentialDesignFactory) -> None:
+        self._design_factory = design_factory
+
+    def build(self, submodules: Sequence[SequentialSubmodule], name: str) -> Design:
+        registry = _Registry()
+        for module in submodules:
+            registry.register(module.__class__.__name__.lower(), module)
+        subdesigns = list(registry.build_designs())
+        return self._design_factory.create_sequential_design(
+            sub_designs=subdesigns, name=name
+        )
+
+
+class _Registry:
+    def __init__(self) -> None:
+        self._nodes: dict[str, SequentialSubmodule] = {}
+        self._name_counters: dict[str, int] = {}
+
+    def _make_name_unique(self, name: str) -> str:
+        return f"{name}_{self._get_counter_for_name(name)}"
+
+    def _get_counter_for_name(self, name: str) -> int:
+        if name in self._name_counters:
+            return self._name_counters[name]
+        else:
+            return 0
+
+    def _increment_name_counter(self, name: str):
+        self._name_counters[name] = 1 + self._get_counter_for_name(name)
+
+    def register(self, name: str, module: SequentialSubmodule):
+        unique_name = self._make_name_unique(name)
+        self._nodes[unique_name] = module
+        self._increment_name_counter(name)
+
+    def build_designs(self) -> Iterator[Design]:
+        for name, module in self._nodes.items():
+            yield module.create_design(name)

--- a/elasticai/creator/nn/sequential/layer.py
+++ b/elasticai/creator/nn/sequential/layer.py
@@ -1,52 +1,31 @@
-from collections.abc import Iterator
 from typing import cast
 
 import torch
 
 from elasticai.creator.nn.design_creator_module import DesignCreatorModule
+from elasticai.creator.nn.sequential.design_builder import (
+    SequentialDesignBuilder,
+    SequentialDesignFactory,
+)
 from elasticai.creator.vhdl.design.design import Design
 
 from .design import Sequential as _SequentialDesign
 
 
+class _DefaultSequentialDesignFactory:
+    def create_sequential_design(self, sub_designs: list[Design], name: str) -> Design:
+        return _SequentialDesign(sub_designs=sub_designs, name=name)
+
+
 class Sequential(DesignCreatorModule, torch.nn.Sequential):
-    def __init__(self, *submodules: DesignCreatorModule):
+    def __init__(
+        self,
+        *submodules: DesignCreatorModule,
+        design_factory: SequentialDesignFactory | None = None,
+    ):
         super().__init__(*submodules)
+        self._design_factory = design_factory or _DefaultSequentialDesignFactory()
 
     def create_design(self, name: str) -> Design:
-        registry = _Registry()
-        submodules = [cast(DesignCreatorModule, m) for m in self.children()]
-        for module in submodules:
-            registry.register(module.__class__.__name__.lower(), module)
-        subdesigns = list(registry.build_designs())
-        return _SequentialDesign(
-            sub_designs=subdesigns,
-            name=name,
-        )
-
-
-class _Registry:
-    def __init__(self) -> None:
-        self._nodes: dict[str, DesignCreatorModule] = {}
-        self._name_counters: dict[str, int] = {}
-
-    def _make_name_unique(self, name: str) -> str:
-        return f"{name}_{self._get_counter_for_name(name)}"
-
-    def _get_counter_for_name(self, name: str) -> int:
-        if name in self._name_counters:
-            return self._name_counters[name]
-        else:
-            return 0
-
-    def _increment_name_counter(self, name: str):
-        self._name_counters[name] = 1 + self._get_counter_for_name(name)
-
-    def register(self, name: str, d: DesignCreatorModule):
-        unique_name = self._make_name_unique(name)
-        self._nodes[unique_name] = d
-        self._increment_name_counter(name)
-
-    def build_designs(self) -> Iterator[Design]:
-        for name, module in self._nodes.items():
-            yield module.create_design(name)
+        submodules = [cast(DesignCreatorModule, module) for module in self.children()]
+        return SequentialDesignBuilder(self._design_factory).build(submodules, name)


### PR DESCRIPTION
This happens in order to prepare the merge of the
add-linear-quantization branch in the follow up
CR.
The `nn.integer` package had need to add additional
files to the sequential implemenatation as well
as to exchange the template. This new design
should allow that without breaking existing clients
or suffering from API leakage/ISP/LSP/SRP violation
