### PR TITLE
feat(ir): data graphs can now be cleared

### DIFF
--- a/elasticai/creator/ir/datagraph.py
+++ b/elasticai/creator/ir/datagraph.py
@@ -80,10 +80,6 @@ class ReadOnlyDataGraph(ReadOnlyGraph[str, AttributeMapping], Protocol[N, E]):
     @abstractmethod
     def edges(self) -> Mapping[tuple[str, str], E]: ...
 
-    @property
-    @abstractmethod
-    def factory(self) -> NodeEdgeFactory[N, E]: ...
-
 
 class DataGraph(ReadOnlyDataGraph[N, E], Graph[str, AttributeMapping], Protocol[N, E]):
     """
@@ -106,7 +102,9 @@ class DataGraph(ReadOnlyDataGraph[N, E], Graph[str, AttributeMapping], Protocol[
     ) -> Self: ...
 
     @abstractmethod
-    def add_nodes(self, *args: Node | tuple[str, AttributeMapping] | str) -> Self: ...
+    def add_nodes(self, *args: Node | tuple[str, AttributeMapping] | str) -> Self:
+        """Updates node in case it exists already."""
+        ...
 
     @overload
     def add_edge(self, edge: Edge, /) -> Self: ...
@@ -119,13 +117,24 @@ class DataGraph(ReadOnlyDataGraph[N, E], Graph[str, AttributeMapping], Protocol[
     @abstractmethod
     def add_edges(
         self, *args: Edge | tuple[str, str, AttributeMapping] | tuple[str, str]
-    ) -> Self: ...
+    ) -> Self:
+        """Updates edge in case it exists already. Possibly already existing nodes remain unchanged."""
+        ...
 
     @abstractmethod
-    def remove_node(self, node: str, /) -> Self: ...
+    def remove_node(self, node: str, /) -> Self:
+        """Will remove node and all connected edges."""
+        ...
 
     @abstractmethod
-    def remove_edge(self, src: str, dst: str) -> Self: ...
+    def remove_edge(self, src: str, dst: str) -> Self:
+        """Will not remove nodes, even if they become isolated."""
+        ...
 
     @abstractmethod
     def with_attributes(self, attributes: AttributeMapping) -> Self: ...
+
+    @abstractmethod
+    def clear(self) -> Self:
+        """Get a new empty graph with attributes, nodes, edges removed."""
+        ...

--- a/elasticai/creator/ir/datagraph_impl.py
+++ b/elasticai/creator/ir/datagraph_impl.py
@@ -179,13 +179,6 @@ class DataGraphImpl[N: Node, E: Edge](DataGraph[N, E]):
     def graph(self) -> Graph[str, AttributeMapping]:
         return self._graph
 
-    def new_from_read_only_data_graph(self, g: ReadOnlyDataGraph) -> Self:
-        return self.new(
-            attributes=g.attributes,
-            node_attributes=g.node_attributes,
-            graph=g.graph,
-        )
-
     @property
     def attributes(self) -> AttributeMapping:
         return self._attributes
@@ -286,7 +279,6 @@ class DataGraphImpl[N: Node, E: Edge](DataGraph[N, E]):
         *nodes: Node | tuple[str, AttributeMapping] | str,
     ) -> Self:
         """Updates nodes in case they exist already."""
-        new_graph = self._graph
         new_nodes_attributes: dict[str, AttributeMapping] = {}
 
         for node in nodes:
@@ -296,7 +288,7 @@ class DataGraphImpl[N: Node, E: Edge](DataGraph[N, E]):
             *(name for name, _ in new_nodes_attributes.items())
         )
         new_nodes = self._nodes | new_nodes_attributes
-        return self.new(
+        return self._new(
             attributes=self._attributes,
             graph=new_graph,
             node_attributes=new_nodes,
@@ -335,7 +327,7 @@ class DataGraphImpl[N: Node, E: Edge](DataGraph[N, E]):
         """Will remove node and all connected edges."""
         new_graph = self._graph.remove_node(node)
         new_nodes = self._nodes.drop(node)
-        return self.new(
+        return self._new(
             attributes=self._attributes,
             graph=new_graph,
             node_attributes=new_nodes,
@@ -344,24 +336,28 @@ class DataGraphImpl[N: Node, E: Edge](DataGraph[N, E]):
     def remove_edge(self, src: str, dst: str) -> Self:
         """Will not remove nodes, even if they become isolated."""
         new_graph = self._graph.remove_edge(src, dst)
-        return self.new(
+        return self._new(
             attributes=self._attributes,
             graph=new_graph,
             node_attributes=self._nodes,
         )
 
     def with_attributes(self, attributes: AttributeMapping) -> Self:
-        return self.new(
+        return self._new(
             attributes=attributes,
             graph=self._graph,
             node_attributes=self._nodes,
         )
 
-    @property
-    def factory(self) -> NodeEdgeFactory[N, E]:
-        return self._factory
+    def clear(self) -> Self:
+        """Get a new empty graph with attributes, nodes, edges removed."""
+        return self._new(
+            attributes=AttributeMapping(),
+            graph=GraphImpl(lambda: AttributeMapping()),
+            node_attributes=AttributeMapping(),
+        )
 
-    def new(
+    def _new(
         self,
         /,
         attributes: AttributeMapping,
@@ -369,7 +365,7 @@ class DataGraphImpl[N: Node, E: Edge](DataGraph[N, E]):
         node_attributes: AttributeMapping,
     ) -> Self:
         return type(self)(
-            factory=self.factory,
+            factory=self._factory,
             attributes=attributes,
             graph=graph,
             node_attributes=node_attributes,

--- a/elasticai/creator/ir2torch/ir2torch.py
+++ b/elasticai/creator/ir2torch/ir2torch.py
@@ -67,7 +67,7 @@ class IrFactory(ir.IrFactory[ir.Node, ir.Edge, ir.DataGraph]):
     ) -> DataGraph:
         if graph is not None:
             return _DataGraph(
-                factory=graph.factory,
+                factory=self,
                 attributes=graph.attributes,
                 graph=graph.graph,
                 node_attributes=graph.node_attributes,


### PR DESCRIPTION
Users can now create a version of a datagraph
with all nodes, edges, attributes removed.

Use Case:

def build_new_graph[G: DataGraph](old: G) -> G:
    new = old.clear()
    for node in old.nodes:
      if node.type == "conv1d":
        new = new.add_node(node)
    return new
