### PR TITLE
fix(shift_register): go back to non circ buff implementation

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -64,7 +64,7 @@ in {
       exec = "${unstablePkgs.uv}/bin/uv run sphinx-autobuild -j auto docs build/docs/";
     };
     run_simulation_tests = {
-      exec = ''${unstablePkgs.uv}/bin/uv run python -m pytest -m simulation '';
+      exec = ''${unstablePkgs.uv}/bin/uv run python -m pytest -m simulation | grep -v "ld:"'';
     };
     run_hw_tests = {
       exec = ''${unstablePkgs.uv}/bin/uv run python -m pytest -m hardware "@$"'';

--- a/src/elasticai/creator/testing/cocotb_stream.py
+++ b/src/elasticai/creator/testing/cocotb_stream.py
@@ -52,11 +52,31 @@ class StreamInterface[TInput, TOutput]:
     and start the coroutine `.collect_chunks()` with `cocotb.start_soon()`
     to read data asynchronously from the dut.
 
+
     In most cases creating a new `StreamInterface` object
     should be done by calling the `.from_dut()` function.
     By default the data is provided and collect as strings,
     but you can use a custom data type, by injecting
     functions for conversion to/from cocotb `LogicArray`s.
+
+    Example:
+
+    ```python
+    cocotb.start_soon(Clock(dut.clk, 10, "ns").start())
+    stream = StreamInterface.from_dut(dut)
+    reset = ResetControl.from_dut(dut)
+    dut.src_valid.value = 0
+    dut.dst_ready.value = 0
+    await RisingEdge(dut.clk)
+    await reset.reset_active_high()
+    dut.en.value = 1
+    collect_task = cocotb.start_soon(
+        stream.collect_chunks(expected_count=1, max_cycles=10)
+    )
+    await stream.drive_chunks([input])
+    observed = await collect_task
+    assert observed == [expected]
+    ```
     """
 
     def __init__(

--- a/src/elasticai/creator_plugins/shift_register/tests/shift_register_test.py
+++ b/src/elasticai/creator_plugins/shift_register/tests/shift_register_test.py
@@ -95,7 +95,7 @@ async def shift_register_accumulates_data(
 
     # we need two cycles to read each data point and one cycle for the valid signal and data to propagate
     num_expected_read_cycles = 2 * len(input_data) * skip + 1
-
+    dut.en.value = 1
     read = ctb.start_soon(
         _record_output_for_n_cycles(
             dut,

--- a/src/elasticai/creator_plugins/shift_register/vhdl/base_shift_register.vhd
+++ b/src/elasticai/creator_plugins/shift_register/vhdl/base_shift_register.vhd
@@ -21,65 +21,31 @@ entity base_shift_register is
 end entity;
 
 architecture rtl of base_shift_register is
-    type buffer_t is array (0 to NUM_POINTS - 1) of std_logic_vector(DATA_WIDTH - 1 downto 0);
-    signal storage : buffer_t := (others => (others => '0'));
-    signal write_ptr : integer range 0 to NUM_POINTS - 1 := 0;
-    signal filled : integer range 0 to NUM_POINTS := 0;
-    signal valid_reg : std_logic := '0';
+    signal storage : std_logic_vector(DATA_WIDTH*NUM_POINTS - 1 downto 0) := (others => '0');
+  
 
-    function build_window(buff : buffer_t; write_pos : integer; fill_count : integer) return std_logic_vector is
-        variable assembled : std_logic_vector(DATA_WIDTH * NUM_POINTS - 1 downto 0) := (others => '0');
-        variable current_index : integer := 0;
-    begin
-        if fill_count > 0 then
-            current_index := write_pos - 1;
-            for chunk_idx in 0 to fill_count - 1 loop
-                if current_index < 0 then
-                    current_index := current_index + NUM_POINTS;
-                end if;
-                assembled((chunk_idx + 1) * DATA_WIDTH - 1 downto chunk_idx * DATA_WIDTH) := buff(current_index);
-                current_index := current_index - 1;
-            end loop;
-        end if;
-        return assembled;
-    end function;
+
 begin
     
-    VALID <= valid_reg;
     READY <= DST_READY;  -- Ready when downstream is ready (simple passthrough)
-    D_OUT <= build_window(storage, write_ptr, filled);
+    D_OUT <= storage;
 
-    update_register : process(CLK, RST)
+    process(CLK) is
+        variable counter : integer := 0;
     begin
-        if RST = '1' then
-            storage <= (others => (others => '0'));
-            write_ptr <= 0;
-            filled <= 0;
-            valid_reg <= '0';
-        elsif rising_edge(CLK) then
-            -- Default: keep valid low unless we're asserting it
-            valid_reg <= '0';
-            -- Level-sensitive handshake: write when both src_valid and dst_ready are high
-            if SRC_VALID = '1' and DST_READY = '1' then
-                storage(write_ptr) <= D_IN;
-                if write_ptr = NUM_POINTS - 1 then
-                    write_ptr <= 0;
-                else
-                    write_ptr <= write_ptr + 1;
-                end if;
-                if filled < NUM_POINTS then
-                    filled <= filled + 1;
-                    -- Assert valid when buffer becomes full (on the cycle we write the last element)
-                    if filled = NUM_POINTS - 1 then
-                        valid_reg <= '1';
+        if rising_edge(CLK) then
+            VALID <= '0';
+            if RST = '1' then
+                counter := 0;
+
+            elsif SRC_VALID = '1' and DST_READY = '1' and EN = '1' then
+                    storage <= storage((DATA_WIDTH*(NUM_POINTS-1))-1 downto 0) & d_in;
+                    if counter < NUM_POINTS - 1 then
+                        counter := counter + 1;
+                    else
+                        VALID <= '1';
                     end if;
-                else
-                    -- Buffer already full, new write creates new valid window
-                    filled <= NUM_POINTS;
-                    valid_reg <= '1';
                 end if;
             end if;
-        end if;
     end process;
-
 end architecture;

--- a/tests/integration_tests/grouped_filter_in_hw/grouped_filter_in_vhdl_test.py
+++ b/tests/integration_tests/grouped_filter_in_hw/grouped_filter_in_vhdl_test.py
@@ -10,6 +10,7 @@ from cocotb.types import LogicArray
 import elasticai.creator.function_dispatch as FD
 import elasticai.creator.ir as ir
 from elasticai.creator import ir2vhdl
+from elasticai.creator.testing import ResetControl, StreamInterface
 from elasticai.creator.testing.cocotb_pytest import CocotbTestFixture
 from elasticai.creator_plugins.grouped_filter import FilterParameters, grouped_filter
 
@@ -249,24 +250,24 @@ async def check_grouped_filter_behaviour(dut):
     xor_input = "000110"
     expected_xnor_filter_results = "11001"
     expected_xor_filter_results = "00101"
-    inputs = [LogicArray("".join((c1, c2))) for c1, c2 in zip(xnor_input, xor_input)]
+    inputs = list("".join(bits) for bits in zip(xnor_input, xor_input))
+    num_steps = len(inputs)
     ctb.start_soon(Clock(dut.clk, period=10).start())
-    dut.dst_ready.value = 1
-    write = ctb.start_soon(_write(dut, inputs, 20))
-    result = []
-    for _ in range(25):
-        if dut.valid.value == 1:
-            result.append(str(dut.d_out.value))
-        await RisingEdge(dut.clk)
-    await write.join()
-
-    xnor_filter_results = "".join(
-        [a for a, _ in result][0 : len(expected_xnor_filter_results)]
+    reset = ResetControl.from_dut(dut)
+    stream = StreamInterface.from_dut(dut)
+    dut.src_valid.value = 0
+    dut.dst_ready.value = 0
+    dut.en.value = 1
+    await RisingEdge(dut.clk)
+    await reset.reset_active_high()
+    collect_task = ctb.start_soon(
+        stream.collect_chunks(expected_count=num_steps, max_cycles=10)
     )
-    xor_filter_results = "".join(
-        [b for _, b in result][0 : len(expected_xor_filter_results)]
-    )
-    assert {"xor": xor_filter_results, "xnor": xnor_filter_results} == {
+    await stream.drive_chunks(inputs)
+    observed = await collect_task
+    xnor_results = "".join([a for a, _ in observed])
+    xor_results = "".join([b for _, b in observed])
+    assert {"xor": xor_results, "xnor": xnor_results} == {
         "xor": expected_xor_filter_results,
         "xnor": expected_xnor_filter_results,
     }


### PR DESCRIPTION
The previous implementation based on a circular buffer was
not synthesizable. Providing a full window to readers
makes a synthesizable implementation rather complex.
This additional control logic poses a significant
overhead by itself. Especially for smaller data widths, an
implementation based on bitshifts might therefore be more
resource efficient. Because of that and lower code complexity,
the previous design is reintroduced. 
