### PR TITLE
chore: remove astray print statements

### DIFF
--- a/src/elasticai/creator/graph/base_graph.py
+++ b/src/elasticai/creator/graph/base_graph.py
@@ -48,7 +48,6 @@ class BaseGraph(Graph[T]):
         for node, successors in d.items():
             g.add_node(node)
             for s in successors:
-                print(f"{s=}")
                 g.add_edge(node, s)
         return g
 

--- a/src/elasticai/creator/graph/graph_iterators.py
+++ b/src/elasticai/creator/graph/graph_iterators.py
@@ -54,12 +54,10 @@ def bfs_iter_down[T](
         visit_next = sorted(list(successors(start)))
     while len(visit_next) > 0:
         current = visit_next.pop(0)
-        print(f"{current=}")
         if current not in visited:
             visited.add(current)
             yield current
             for child in successors(current):
-                print(f"\t{child=}")
                 if set(predecessors(child)).issubset(visited):
                     visit_next.append(child)
 

--- a/src/elasticai/creator/ir/graph.py
+++ b/src/elasticai/creator/ir/graph.py
@@ -165,8 +165,6 @@ class GraphImpl[T: Hashable, E](Graph[T, E]):
                 additional_predecessors[src] = {}
         new_successors = self.successors.join(additional_successors)
         new_predecessors = self.predecessors.join(additional_predecessors)
-        print(f"{new_predecessors}")
-        print(f"{new_successors}")
         return type(self)(
             self._default_edge_attributes_factory,
             predecessors=new_predecessors,


### PR DESCRIPTION
Prefer logging to prints. Also the
removed print statements were supposed to
be temporary.
