### PR TITLE
chore(devenv): disable automatic uv sync on devenv enterShell

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -37,8 +37,6 @@ in {
     package = pkgs.python312;
     uv.enable = true;
     uv.package = unstablePkgs.uv;
-    uv.sync.enable = true;
-    uv.sync.allExtras = true;
   };
   processes = {
     serve_docs.exec = "serve_docs";


### PR DESCRIPTION
The behaviour made it more difficult to deal with problems
that would occur from a failed uv sync. Even more, it
made offline rebuilds of devenv unusable as you could
not enable uv's offline mode and uv does not automatically
switch to it.
