### PR TITLE
feat: add function type to torch2ir/ir2torch representing function calls

### DIFF
--- a/src/elasticai/creator/experimental/ir/shape_inference/default_handlers.py
+++ b/src/elasticai/creator/experimental/ir/shape_inference/default_handlers.py
@@ -39,9 +39,9 @@ def _register_type(
 def get_default_shape_inference() -> IrShapeInference:
     infer = IrShapeInference()
     for m in _module_handlers:
-        infer.register()(m)
+        infer.register_dgraph()(m)
     for t in _type_handlers:
-        infer.register_type()(t)
+        infer.register_node()(t)
     return infer
 
 

--- a/src/elasticai/creator/experimental/ir/shape_inference/shape_inference.py
+++ b/src/elasticai/creator/experimental/ir/shape_inference/shape_inference.py
@@ -62,15 +62,19 @@ class IrShapeInference:
             output_shape = self._get_out_shape_for_node(node, input_shapes)
             self._add_outgoing_edges(node.name, output_shape)
 
+    def _should_look_up_in_shapes_from_nodes_handlers(self, node: ir.Node):
+        return (
+            "implementation" not in node.attributes
+            or node.type == "function"
+            or self._get_node_impl(node).attributes["type"]
+            not in self._get_out_shape_from_dgraph.registry
+        )
+
     def _get_out_shape_for_node(
         self, node: ir.Node, input_shapes: tuple[Shape, ...]
     ) -> Shape:
-        if (
-            "implementation" not in node.attributes
-            or self._get_node_impl(node).attributes["type"]
-            not in self._get_out_shape_from_dgraph.registry
-        ):
-            return self._get_out_shape_for_type(node, input_shapes)
+        if self._should_look_up_in_shapes_from_nodes_handlers(node):
+            return self._get_out_shape_from_node(node, input_shapes)
 
         impl = self._get_node_impl(node.name)
         return self._get_out_shape_from_dgraph(impl, input_shapes)
@@ -135,13 +139,13 @@ class IrShapeInference:
         return fn(graph, input_shapes)
 
     @_get_out_shape_from_dgraph.key_from_args
-    def _get_type_from_dg_node(
+    def _get_type_from_dg(
         self, graph: DataGraph, input_shapes: tuple[Shape, ...]
     ) -> str:
         return cast(str, graph.attributes["type"])
 
     @FD.dispatch_method(str)
-    def _get_out_shape_for_type(
+    def _get_out_shape_from_node(
         self,
         fn: Callable[[tuple[Shape, ...]], Shape],
         node: ir.Node,
@@ -149,22 +153,24 @@ class IrShapeInference:
     ) -> Shape:
         return fn(input_shapes)
 
-    @_get_out_shape_for_type.key_from_args
+    @_get_out_shape_from_node.key_from_args
     def _get_node_type(self, node: ir.Node, input_shapes: tuple[Shape, ...]) -> str:
+        if node.type == "function":
+            return node.attributes["implementation"]
         return node.type
 
     @FD.registrar_method
-    def register(self, key: str | None, fn: TypeHandler) -> TypeHandler:
+    def register_dgraph(self, key: str | None, fn: TypeHandler) -> TypeHandler:
         key = self._check_and_get_name(key, fn)
         self._get_out_shape_from_dgraph.register(key, fn)
         return fn
 
     @FD.registrar_method
-    def register_type(
+    def register_node(
         self, key: str | None, fn: Callable[[tuple[Shape, ...]], Shape]
     ) -> Callable[[tuple[Shape, ...]], Shape]:
         key = self._check_and_get_name(key, fn)
-        self._get_out_shape_for_type.register(key, fn)
+        self._get_out_shape_from_node.register(key, fn)
         return fn
 
     @staticmethod

--- a/src/elasticai/creator/experimental/ir/shape_inference/tests/ir2shapes_test.py
+++ b/src/elasticai/creator/experimental/ir/shape_inference/tests/ir2shapes_test.py
@@ -60,99 +60,35 @@ def test_ir2shapes(convert2ir):
     root, reg = convert2ir(m)
     translator = shape_translator()
     new_graph = translator(root, reg, {"input_1": (5, 1)})
-    assert serialize(new_graph, reg) == {
-        "0": {
-            "type": "linear",
-            "in_features": 1,
-            "out_features": 2,
-            "bias": True,
-            "nodes": {},
-            "edges": {},
-        },
-        "1": {"type": "relu", "nodes": {}, "edges": {}},
-        "": {
-            "type": "module",
-            "nodes": {
-                "input_1": {"type": "input", "implementation": "input"},
-                "_0": {"type": "linear", "implementation": "0"},
-                "_1": {"type": "relu", "implementation": "1"},
-                "output": {"type": "output", "implementation": "output"},
-            },
-            "edges": {
-                "input_1": {"_0": {"shape": (5, 1)}},
-                "_0": {"_1": {"shape": (5, 2)}},
-                "_1": {"output": {"shape": (5, 2)}},
-                "output": {},
-            },
-        },
+
+    expected_edges = {
+        ("input_1", "_0", (5, 1)),
+        ("_0", "_1", (5, 2)),
+        ("_1", "output", (5, 2)),
     }
+    actual_edges = {(e.src, e.dst, e.shape) for e in new_graph.edges.values()}
+    assert expected_edges == actual_edges
 
 
 def test_ir2shapes_skip_connection(convert2ir):
-    shape = (5, 2, 6, 6)
+    input_shape = (5, 2, 6, 6)
     m = model_skip_connection()
     root, reg = convert2ir(m)
     translator = shape_translator()
-    new_graph = translator(root, reg, {"x": shape})
-    assert serialize(new_graph, reg) == {
-        "conv2d": {
-            "type": "conv2d",
-            "in_channels": 2,
-            "out_channels": 2,
-            "kernel_size": (3, 3),
-            "stride": (1, 1),
-            "padding": "same",
-            "dilation": (1, 1),
-            "groups": 1,
-            "bias": True,
-            "padding_mode": "zeros",
-            "nodes": {},
-            "edges": {},
-        },
-        "relu": {"type": "relu", "nodes": {}, "edges": {}},
-        "batchnorm2d": {
-            "type": "batchnorm2d",
-            "num_features": 2,
-            "affine": True,
-            "nodes": {},
-            "edges": {},
-        },
-        "add": {"type": "add", "nodes": {}, "edges": {}},
-        "flatten": {"type": "flatten", "nodes": {}, "edges": {}},
-        "linear": {
-            "type": "linear",
-            "in_features": 72,
-            "out_features": 1,
-            "bias": True,
-            "nodes": {},
-            "edges": {},
-        },
-        "": {
-            "type": "module",
-            "nodes": {
-                "x": {"type": "input", "implementation": "input"},
-                "conv2d": {"type": "conv2d", "implementation": "conv2d"},
-                "add": {"type": "add", "implementation": "add"},
-                "relu": {"type": "relu", "implementation": "relu"},
-                "batchnorm2d": {"type": "batchnorm2d", "implementation": "batchnorm2d"},
-                "flatten": {"type": "flatten", "implementation": "flatten"},
-                "linear": {"type": "linear", "implementation": "linear"},
-                "relu_1": {"type": "relu", "implementation": "relu"},
-                "output": {"type": "output", "implementation": "output"},
-            },
-            "edges": {
-                "x": {
-                    "conv2d": {"shape": (5, 2, 6, 6)},
-                    "add": {"shape": (5, 2, 6, 6)},
-                },
-                "conv2d": {"relu": {"shape": (5, 2, 6, 6)}},
-                "add": {"flatten": {"shape": (5, 2, 6, 6)}},
-                "relu": {"batchnorm2d": {"shape": (5, 2, 6, 6)}},
-                "batchnorm2d": {"add": {"shape": (5, 2, 6, 6)}},
-                "flatten": {"linear": {"shape": (5, 72)}},
-                "linear": {"relu_1": {"shape": (5, 1)}},
-                "relu_1": {"output": {"shape": (5, 1)}},
-                "output": {},
-            },
-        },
+    new_graph = translator(root, reg, {"x": input_shape})
+    expected_shapes = {
+        (a, b): s
+        for a, b, s in (
+            ("x", "conv2d", input_shape),
+            ("x", "add", input_shape),
+            ("conv2d", "relu", input_shape),
+            ("batchnorm2d", "add", input_shape),
+            ("add", "flatten", input_shape),
+            ("relu", "batchnorm2d", input_shape),
+            ("flatten", "linear", (5, 72)),
+            ("linear", "relu_1", (5, 1)),
+            ("relu_1", "output", (5, 1)),
+        )
     }
+    actual_shapes = {(e.src, e.dst): e.shape for e in new_graph.edges.values()}
+    assert expected_shapes == actual_shapes

--- a/src/elasticai/creator/experimental/ir/shape_inference/tests/unit_test.py
+++ b/src/elasticai/creator/experimental/ir/shape_inference/tests/unit_test.py
@@ -14,7 +14,7 @@ factory = ir.DefaultIrFactory()
 def infer_shape():
     infer = get_default_shape_inference()
 
-    @infer.register_type()
+    @infer.register_node()
     def scalar_function(input_shape: tuple[Shape, ...]) -> Shape:
         if len(input_shape) > 1:
             raise ValueError("Scalar function cannot take more than single argument")
@@ -33,7 +33,7 @@ def _base_graph():
 
 @pytest.fixture
 def _graph_with_datapath_join(_base_graph: ir.DataGraph[ir.Node, ir.Edge]):
-    add_attr = ir.attribute(type="add")
+    add_attr = ir.attribute(type="function", implementation="add")
     scalar_attr = ir.attribute(type="scalar_function")
     return (
         _base_graph.with_attributes(ir.attribute(name="child_module"))

--- a/src/elasticai/creator/ir2torch/__init__.py
+++ b/src/elasticai/creator/ir2torch/__init__.py
@@ -1,4 +1,4 @@
-from .default_handlers import handlers as default_handlers
+from .default_handlers import dgraph_handlers as default_handlers
 from .ir2torch import (
     Ir2Torch,
     IrFactory,

--- a/src/elasticai/creator/ir2torch/default_handlers.py
+++ b/src/elasticai/creator/ir2torch/default_handlers.py
@@ -1,18 +1,34 @@
-from typing import cast
+from collections.abc import Callable
+from typing import Any, cast
 
+import torch
 from torch import nn
 
 import elasticai.creator.ir as ir
+from elasticai.creator import function_dispatch as FD
 
-handlers = []
+dgraph_handlers = []
+node_handlers = {}
 
 
-def _register(fn):
-    handlers.append(fn)
+def _register_dgraph(fn):
+    dgraph_handlers.append(fn)
     return fn
 
 
-@_register
+@FD.registrar
+def _register_node(
+    key: str | None, fn: Callable[[ir.Node], Callable[[Any], torch.Tensor]]
+):
+    if key is None:
+        if not hasattr(fn, "__name__"):
+            raise TypeError("only functions are supported")
+        key = cast(str, fn.__name__)
+    node_handlers[key] = fn
+    return fn
+
+
+@_register_dgraph
 def linear(impl: ir.DataGraph) -> nn.Module:
     if not hasattr(impl, "data"):
         attrs = impl.attributes
@@ -23,12 +39,12 @@ def linear(impl: ir.DataGraph) -> nn.Module:
     )
 
 
-@_register
+@_register_dgraph
 def relu(impl: ir.DataGraph) -> nn.Module:
     return nn.ReLU()
 
 
-@_register
+@_register_dgraph
 def conv1d(impl: ir.DataGraph) -> nn.Conv1d:
     keywords = (
         "in_channels",
@@ -48,11 +64,30 @@ def conv1d(impl: ir.DataGraph) -> nn.Conv1d:
     return nn.Conv1d(**kwargs)  # type: ignore
 
 
-@_register
+@_register_dgraph
 def sigmoid(impl: ir.DataGraph) -> nn.Sigmoid:
     return nn.Sigmoid()
 
 
-@_register
+@_register_dgraph
 def flatten(imp: ir.DataGraph) -> nn.Flatten:
     return nn.Flatten()
+
+
+@_register_dgraph
+def function(imp: ir.DataGraph) -> nn.Module:
+    class FunctionWrapper(nn.Module):
+        def __init__(self):
+            self._fn = getattr(torch, imp.attributes["type"])
+
+        def forward(self, *args, **kwargs):
+            return self._fn(*args, **kwargs)
+
+    return FunctionWrapper()
+
+
+@_register_node("flatten")
+@_register_node("add")
+def handle_functions(node: ir.Node) -> Callable[[Any], torch.Tensor]:
+    fn_name = node.attributes["implementation"]
+    return getattr(torch, fn_name)

--- a/src/elasticai/creator/ir2torch/ir2torch.py
+++ b/src/elasticai/creator/ir2torch/ir2torch.py
@@ -2,13 +2,14 @@ from collections.abc import Callable
 from itertools import starmap
 from typing import Any, Protocol
 
+import torch
 import torch.nn as nn
 from torch import fx
 
 import elasticai.creator.function_dispatch as FD
 from elasticai.creator import ir
 
-from .default_handlers import handlers
+from .default_handlers import dgraph_handlers, node_handlers
 
 
 class DataGraph(ir.DataGraph[ir.Node, ir.Edge], Protocol):
@@ -92,6 +93,16 @@ class Ir2Torch:
     def _get_key_from_data_graph(self, dgraph: DataGraph) -> str:
         return dgraph.type
 
+    @FD.dispatch_method(str)
+    def _make_fn_call(
+        self, fn: Callable[[ir.Node], Callable[[Any], torch.Tensor]], node: ir.Node, /
+    ) -> Callable[[Any], torch.Tensor]:
+        return fn(node)
+
+    @_make_fn_call.key_from_args
+    def _key_for_fn_call(self, node: ir.Node) -> str:
+        return node.attributes["implementation"]
+
     @staticmethod
     def _check_and_get_name_from_fn(name, fn) -> str:
         if name is None:
@@ -110,6 +121,14 @@ class Ir2Torch:
         fn: TypeHandler,
     ) -> TypeHandler:
         return self._build_submodule.register(
+            self._check_and_get_name_from_fn(name, fn), fn
+        )
+
+    @FD.registrar_method
+    def register_node(
+        self, name: str | None, fn: Callable[[ir.Node], Callable[[Any], torch.Tensor]]
+    ):
+        return self._make_fn_call.register(
             self._check_and_get_name_from_fn(name, fn), fn
         )
 
@@ -168,32 +187,40 @@ class Ir2Torch:
         nodes: dict[str, fx.Node] = {}
 
         def _add_node(ir_node: str) -> None:
-            node_type = ir_root.nodes[ir_node].type
-            node_impl: str = ir_root.nodes[ir_node].attributes["implementation"]
-            if ir_root.nodes[ir_node].type not in ("input", "output"):
-                predecessors = tuple(
-                    nodes[node] for node in ir_root.predecessors[ir_node]
-                )
-                node = graph.create_node(
-                    op="call_module",
-                    target=node_impl,
-                    args=predecessors,
-                    name=ir_node,
-                )
-                nodes[ir_node] = node
-            elif node_type == "input":
-                n = graph.create_node(op="placeholder", name=ir_node, target=ir_node)
-                nodes[ir_node] = n
-            elif node_type == "output":
-                predecessors = tuple(
-                    nodes[node] for node in ir_root.predecessors[ir_node]
-                )
-                n = graph.create_node(
-                    op="output",
-                    target=ir_node,
-                    args=predecessors,
-                )
-                nodes[ir_node] = n
+            node = ir_root.nodes[ir_node]
+            match node.type:
+                case "input":
+                    n = graph.create_node(
+                        op="placeholder", name=node.name, target=node.name
+                    )
+                    nodes[node.name] = n
+                case "output":
+                    predecessors = tuple(
+                        nodes[node] for node in ir_root.predecessors[node.name]
+                    )
+                    n = graph.create_node(
+                        op="output",
+                        target=ir_node,
+                        args=predecessors,
+                    )
+                    nodes[ir_node] = n
+                case _:
+                    predecessors = tuple(
+                        nodes[n] for n in ir_root.predecessors[ir_node]
+                    )
+                    if node.type == "function":
+                        op = "call_function"
+                        target = self._make_fn_call(node)
+                    else:
+                        op = "call_module"
+                        target = node.attributes["implementation"]
+                    fxnode = graph.create_node(
+                        op=op,
+                        target=target,
+                        args=predecessors,
+                        name=ir_node,
+                    )
+                    nodes[ir_node] = fxnode
 
         def visit_node(ir_node: str):
             if ir_node not in nodes:
@@ -218,6 +245,8 @@ class Ir2Torch:
 
 def get_default_converter() -> Ir2Torch:
     converter = Ir2Torch()
-    for handler in handlers:
+    for handler in dgraph_handlers:
         converter.register()(handler)
+    for name, handler in node_handlers.items():
+        converter.register_node(name, handler)
     return converter

--- a/src/elasticai/creator/torch2ir/torch2ir.py
+++ b/src/elasticai/creator/torch2ir/torch2ir.py
@@ -65,21 +65,21 @@ class Torch2Ir:
         return fn
 
     def _handle_fx_node(self, node: FxNode) -> None:
-        self._root = self._root.add_node(
-            node.name,
-            ir.attribute(
-                type=self._get_type(node), implementation=self._get_implementation(node)
-            ),
-        )
+        attribute = ir.attribute(type=self._get_type(node))
+        if self._has_implementation(node):
+            attribute |= dict(implementation=self._get_implementation(node))
+
+        self._root = self._root.add_node(node.name, attribute)
         ir_node = self._root.nodes[node.name]
-        impl = ir_node.attributes["implementation"]
-        if impl not in self._registry and impl not in ("input", "output"):
-            attributes = self._extract_attributes(node)
-            self._registry = self._registry | {
-                impl: self._ir_factory.graph(
-                    ir.attribute(type=ir_node.type, **attributes),
-                )
-            }
+        if self._has_implementation(node):
+            impl = ir_node.attributes["implementation"]
+            if impl not in self._registry and ir_node.type != "function":
+                attributes = self._extract_attributes(node)
+                self._registry = self._registry | {
+                    impl: self._ir_factory.graph(
+                        ir.attribute(type=ir_node.type, **attributes),
+                    )
+                }
         for successor in self._get_successors(node):
             self._root = self._root.add_edge(node.name, successor.name)
 
@@ -111,11 +111,7 @@ class Torch2Ir:
                 ).__name__.lower()
 
             case "call_function":
-                if "add" in node.name:
-                    return "add"
-                elif "flatten" in node.name:
-                    return "flatten"
-                raise error
+                return "function"
             case "placeholder":
                 return "input"
             case "output":
@@ -125,21 +121,22 @@ class Torch2Ir:
             case _:
                 raise Exception(f"Unknown node type: {node.op}")
 
+    def _has_implementation(self, node: FxNode) -> bool:
+        return self._get_type(node) not in ("input", "output")
+
     def _get_implementation(self, node: FxNode) -> str:
-        match self._get_type(node):
-            case "input":
-                return "input"
-            case "output":
-                return "output"
-            case "add":
-                return "add"
-            case "flatten":
-                return "flatten"
-            case _:
+        match node.op:
+            case "call_module":
                 return cast(str, node.target)
+            case "call_function":
+                return node.target.__name__  # type: ignore
+            case _:
+                raise ValueError(
+                    f"unsupported operation {node.op} for node {node.name}"
+                )
 
     def _extract_attributes(self, node: FxNode) -> dict:
-        if self._get_type(node) in ("input", "output", "add", "flatten"):
+        if self._get_type(node) in ("input", "output", "function"):
             return {}
         module = self.model.get_submodule(cast(str, node.target))
         return self._extractors(module)
@@ -162,7 +159,7 @@ class Torch2IrWithParams(Torch2Ir):
         return params
 
     def _extract_attributes(self, node: FxNode) -> dict:
-        if self._get_type(node) in ("input", "output", "add", "flatten"):
+        if self._get_type(node) in ("input", "output", "function"):
             return {}
         module = self.model.get_submodule(cast(str, node.target))
         return self._extractors(module) | self._add_params(module)
@@ -176,7 +173,7 @@ class Torch2IrWithParamsAndBuffers(Torch2IrWithParams):
         return buffers
 
     def _extract_attributes(self, node: FxNode) -> dict:
-        if self._get_type(node) in ("input", "output", "add", "flatten"):
+        if self._get_type(node) in ("input", "output", "function"):
             return {}
         module = self.model.get_submodule(cast(str, node.target))
         return (

--- a/tests/integration_tests/torch2ir_test.py
+++ b/tests/integration_tests/torch2ir_test.py
@@ -121,7 +121,6 @@ def test_convert_resnet_to_ir():
             "nodes": {},
             "edges": {},
         },
-        "add": {"type": "add", "nodes": {}, "edges": {}},
         "layer1.1.conv1": {
             "type": "conv2d",
             "in_channels": 64,
@@ -492,7 +491,6 @@ def test_convert_resnet_to_ir():
             "nodes": {},
             "edges": {},
         },
-        "flatten": {"type": "flatten", "nodes": {}, "edges": {}},
         "fc": {
             "type": "linear",
             "in_features": 512,
@@ -504,7 +502,9 @@ def test_convert_resnet_to_ir():
         "": {
             "type": "module",
             "nodes": {
-                "x": {"type": "input", "implementation": "input"},
+                "x": {
+                    "type": "input",
+                },
                 "conv1": {"type": "conv2d", "implementation": "conv1"},
                 "bn1": {"type": "batchnorm2d", "implementation": "bn1"},
                 "relu": {"type": "relu", "implementation": "relu"},
@@ -513,7 +513,7 @@ def test_convert_resnet_to_ir():
                     "type": "conv2d",
                     "implementation": "layer1.0.conv1",
                 },
-                "add": {"type": "add", "implementation": "add"},
+                "add": {"type": "function", "implementation": "add"},
                 "layer1_0_bn1": {
                     "type": "batchnorm2d",
                     "implementation": "layer1.0.bn1",
@@ -532,7 +532,7 @@ def test_convert_resnet_to_ir():
                     "type": "conv2d",
                     "implementation": "layer1.1.conv1",
                 },
-                "add_1": {"type": "add", "implementation": "add"},
+                "add_1": {"type": "function", "implementation": "add"},
                 "layer1_1_bn1": {
                     "type": "batchnorm2d",
                     "implementation": "layer1.1.bn1",
@@ -568,7 +568,7 @@ def test_convert_resnet_to_ir():
                     "type": "batchnorm2d",
                     "implementation": "layer2.0.bn2",
                 },
-                "add_2": {"type": "add", "implementation": "add"},
+                "add_2": {"type": "function", "implementation": "add"},
                 "layer2_0_downsample_1": {
                     "type": "batchnorm2d",
                     "implementation": "layer2.0.downsample.1",
@@ -578,7 +578,7 @@ def test_convert_resnet_to_ir():
                     "type": "conv2d",
                     "implementation": "layer2.1.conv1",
                 },
-                "add_3": {"type": "add", "implementation": "add"},
+                "add_3": {"type": "function", "implementation": "add"},
                 "layer2_1_bn1": {
                     "type": "batchnorm2d",
                     "implementation": "layer2.1.bn1",
@@ -614,7 +614,7 @@ def test_convert_resnet_to_ir():
                     "type": "batchnorm2d",
                     "implementation": "layer3.0.bn2",
                 },
-                "add_4": {"type": "add", "implementation": "add"},
+                "add_4": {"type": "function", "implementation": "add"},
                 "layer3_0_downsample_1": {
                     "type": "batchnorm2d",
                     "implementation": "layer3.0.downsample.1",
@@ -624,7 +624,7 @@ def test_convert_resnet_to_ir():
                     "type": "conv2d",
                     "implementation": "layer3.1.conv1",
                 },
-                "add_5": {"type": "add", "implementation": "add"},
+                "add_5": {"type": "function", "implementation": "add"},
                 "layer3_1_bn1": {
                     "type": "batchnorm2d",
                     "implementation": "layer3.1.bn1",
@@ -660,7 +660,7 @@ def test_convert_resnet_to_ir():
                     "type": "batchnorm2d",
                     "implementation": "layer4.0.bn2",
                 },
-                "add_6": {"type": "add", "implementation": "add"},
+                "add_6": {"type": "function", "implementation": "add"},
                 "layer4_0_downsample_1": {
                     "type": "batchnorm2d",
                     "implementation": "layer4.0.downsample.1",
@@ -670,7 +670,7 @@ def test_convert_resnet_to_ir():
                     "type": "conv2d",
                     "implementation": "layer4.1.conv1",
                 },
-                "add_7": {"type": "add", "implementation": "add"},
+                "add_7": {"type": "function", "implementation": "add"},
                 "layer4_1_bn1": {
                     "type": "batchnorm2d",
                     "implementation": "layer4.1.bn1",
@@ -686,9 +686,9 @@ def test_convert_resnet_to_ir():
                 },
                 "layer4_1_relu_1": {"type": "relu", "implementation": "layer4.1.relu"},
                 "avgpool": {"type": "adaptiveavgpool2d", "implementation": "avgpool"},
-                "flatten": {"type": "flatten", "implementation": "flatten"},
+                "flatten": {"type": "function", "implementation": "flatten"},
                 "fc": {"type": "linear", "implementation": "fc"},
-                "output": {"type": "output", "implementation": "output"},
+                "output": {"type": "output"},
             },
             "edges": {
                 "x": {"conv1": {}},

--- a/tests/unit_tests/torch2ir_test.py
+++ b/tests/unit_tests/torch2ir_test.py
@@ -103,7 +103,6 @@ def test_convert_big_with_params():
             "type": "module",
             "nodes": {
                 "input_1": {
-                    "implementation": "input",
                     "type": "input",
                 },
                 "_0": {
@@ -115,7 +114,6 @@ def test_convert_big_with_params():
                     "type": "relu",
                 },
                 "output": {
-                    "implementation": "output",
                     "type": "output",
                 },
             },
@@ -169,10 +167,14 @@ def test_convert_linear_model_to_ir():
         "": {
             "type": "module",
             "nodes": {
-                "input_1": {"type": "input", "implementation": "input"},
+                "input_1": {
+                    "type": "input",
+                },
                 "_0": {"type": "linear", "implementation": "0"},
                 "_1": {"type": "relu", "implementation": "1"},
-                "output": {"type": "output", "implementation": "output"},
+                "output": {
+                    "type": "output",
+                },
             },
             "edges": {
                 "input_1": {"_0": {}},
@@ -188,7 +190,6 @@ def test_convert_skip_connection_model_to_ir():
     m = model_skip_connection()
     ir = convert(m)
     assert ir == {
-        "add": {"edges": {}, "nodes": {}, "type": "add"},
         "batchnorm2d": {
             "affine": True,
             "edges": {},
@@ -210,7 +211,11 @@ def test_convert_skip_connection_model_to_ir():
             "stride": (1, 1),
             "type": "conv2d",
         },
-        "flatten": {"edges": {}, "nodes": {}, "type": "flatten"},
+        "flatten": {
+            "edges": {},
+            "nodes": {},
+            "type": "flatten",
+        },
         "linear": {
             "bias": True,
             "edges": {},
@@ -223,15 +228,15 @@ def test_convert_skip_connection_model_to_ir():
         "": {
             "type": "module",
             "nodes": {
-                "add": {"implementation": "add", "type": "add"},
+                "add": {"type": "function", "implementation": "add"},
                 "batchnorm2d": {"implementation": "batchnorm2d", "type": "batchnorm2d"},
                 "conv2d": {"implementation": "conv2d", "type": "conv2d"},
                 "flatten": {"implementation": "flatten", "type": "flatten"},
                 "linear": {"implementation": "linear", "type": "linear"},
-                "output": {"implementation": "output", "type": "output"},
+                "output": {"type": "output"},
                 "relu": {"implementation": "relu", "type": "relu"},
                 "relu_1": {"implementation": "relu", "type": "relu"},
-                "x": {"implementation": "input", "type": "input"},
+                "x": {"type": "input"},
             },
             "edges": {
                 "add": {"flatten": {}},
@@ -259,7 +264,6 @@ def test_convert_linear_without_bias():
             "nodes": {
                 "input_1": {
                     "type": "input",
-                    "implementation": "input",
                 },
                 "_0": {
                     "type": "linear",
@@ -267,7 +271,6 @@ def test_convert_linear_without_bias():
                 },
                 "output": {
                     "type": "output",
-                    "implementation": "output",
                 },
             },
             "edges": {
@@ -299,7 +302,6 @@ def test_convert_linear_to_ir():
             "type": "module",
             "nodes": {
                 "input_1": {
-                    "implementation": "input",
                     "type": "input",
                 },
                 "_0": {
@@ -311,7 +313,6 @@ def test_convert_linear_to_ir():
                     "type": "relu",
                 },
                 "output": {
-                    "implementation": "output",
                     "type": "output",
                 },
             },
@@ -359,7 +360,6 @@ def test_converting_model_with_batchnorm():
             },
             "nodes": {
                 "x": {
-                    "implementation": "input",
                     "type": "input",
                 },
                 "bn": {
@@ -371,7 +371,6 @@ def test_converting_model_with_batchnorm():
                     "type": "relu",
                 },
                 "output": {
-                    "implementation": "output",
                     "type": "output",
                 },
             },
@@ -402,7 +401,6 @@ def test_can_handle_same_object_under_different_hierarchy_paths():
             "nodes": {
                 "input_1": {
                     "type": "input",
-                    "implementation": "input",
                 },
                 "a": {
                     "type": "linear",
@@ -414,7 +412,6 @@ def test_can_handle_same_object_under_different_hierarchy_paths():
                 },
                 "output": {
                     "type": "output",
-                    "implementation": "output",
                 },
             },
             "edges": {
@@ -443,7 +440,6 @@ def test_can_handle_nested_hierarchies():
             "nodes": {
                 "input_1": {
                     "type": "input",
-                    "implementation": "input",
                 },
                 "top_nested": {
                     "type": "linear",
@@ -451,7 +447,6 @@ def test_can_handle_nested_hierarchies():
                 },
                 "output": {
                     "type": "output",
-                    "implementation": "output",
                 },
             },
             "edges": {


### PR DESCRIPTION
Function calls are now represented by nodes of type "function" and
with an implementation field denoting the name of the function.

BREAKING CHANGE: breaks clients that were relying on functions not
having an implementation field. If you need the old behaviour write
a small translation pass that replaces the "function" type by
the corresponding "implementation" field and removes said field.
