### PR TITLE
fix(torch2ir): handle Flatten layers correctly

### DIFF
--- a/src/elasticai/creator/ir2torch/default_handlers.py
+++ b/src/elasticai/creator/ir2torch/default_handlers.py
@@ -71,7 +71,9 @@ def sigmoid(impl: ir.DataGraph) -> nn.Sigmoid:
 
 @_register_dgraph
 def flatten(imp: ir.DataGraph) -> nn.Flatten:
-    return nn.Flatten()
+    return nn.Flatten(
+        start_dim=imp.attributes["start_dim"], end_dim=imp.attributes["end_dim"]
+    )
 
 
 @_register_dgraph

--- a/src/elasticai/creator/torch2ir/default_handlers.py
+++ b/src/elasticai/creator/torch2ir/default_handlers.py
@@ -54,7 +54,7 @@ def batchnorm1d(module: nn.BatchNorm1d) -> dict:
 
 @_register
 def flatten(module: nn.Flatten) -> dict:
-    return {}
+    return {"start_dim": module.start_dim, "end_dim": module.end_dim}
 
 
 @_register

--- a/tests/integration_tests/torch2ir2torch_test.py
+++ b/tests/integration_tests/torch2ir2torch_test.py
@@ -1,5 +1,6 @@
 import hypothesis.strategies as st
 import pytest
+import torch
 from hypothesis import settings as hypothesis_settings
 from hypothesis.stateful import (
     RuleBasedStateMachine,
@@ -118,3 +119,13 @@ class BuildModelFromIr(RuleBasedStateMachine):
 
 
 BuildModelFromIrTest = pytest.mark.slow()(BuildModelFromIr.TestCase)
+
+
+def test_can_handle_model_with_flattening_layer():
+    model = Sequential(Flatten(start_dim=2))
+    x = torch.rand((3, 4, 5))
+    expected = model(x)
+    ir_representation = convert(model)
+    reconstructed_model = ir2torch(ir_representation)
+    actual = reconstructed_model(x)
+    assert expected.shape == actual.shape

--- a/tests/unit_tests/torch2ir_test.py
+++ b/tests/unit_tests/torch2ir_test.py
@@ -215,6 +215,8 @@ def test_convert_skip_connection_model_to_ir():
             "edges": {},
             "nodes": {},
             "type": "flatten",
+            "start_dim": 1,
+            "end_dim": -1,
         },
         "linear": {
             "bias": True,


### PR DESCRIPTION
Previous implementation was not respecting start
and end dimensions.
