### PR TITLE
feat(testing.cocotb_pytest): support collecting src files from packages

### DIFF
--- a/src/elasticai/creator/file_generation/resource_utils.py
+++ b/src/elasticai/creator/file_generation/resource_utils.py
@@ -13,6 +13,14 @@ def get_file_from_package(package: Package, file_name: str) -> ContextManager[Pa
     will take care of removing the resulting temporary files on __exit__
     """
     file_path = list(Path(file_name).parts)
+    if not isinstance(package, str):
+        package = package.__name__
+    package_parts = package.split(".")
+    while ".." == file_path[0]:
+        file_path.pop(0)
+        package_parts.pop(-1)
+    package = ".".join(package_parts)
+
     current_resource = resources.files(package)
     dir_contents = current_resource.iterdir()
     try:

--- a/src/elasticai/creator/testing/cocotb_pytest.py
+++ b/src/elasticai/creator/testing/cocotb_pytest.py
@@ -5,6 +5,7 @@ import json
 from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping, Sequence
 from contextlib import ExitStack
 from functools import wraps
+from importlib.resources import Anchor
 from os import environ
 from pathlib import Path
 from typing import Any
@@ -131,6 +132,18 @@ class CocotbTestFixture:
             except (ModuleNotFoundError, FileNotFoundError):
                 pass
 
+    def add_srcs_from_package(self, package: Anchor, glob_pattern: str) -> None:
+        package_dir = importlib.resources.as_file(
+            importlib.resources.files(package),
+        )
+        opened_package_dir = self._context_stack.enter_context(package_dir)
+        self._srcs.extend(
+            (
+                str(p.absolute().as_posix())
+                for p in opened_package_dir.glob(glob_pattern)
+            )
+        )
+
     def _create_build_dir(self):
         build_test_subdir = create_name_for_build_test_subdir(
             self._test_fn, *self._args, **self._kwargs
@@ -159,6 +172,7 @@ class CocotbTestFixture:
         self._top_module_name = top_module_name
 
     def set_srcs(self, srcs: Iterable[str | Path]):
+        self._context_stack.close()
         self._srcs = list((str(s) for s in srcs))
 
     def add_srcs(self, *srcs: str | Path) -> None:

--- a/tests/integration_tests/cocotb_pytest/test/cocotb_pytest_test.py
+++ b/tests/integration_tests/cocotb_pytest/test/cocotb_pytest_test.py
@@ -1,11 +1,11 @@
+from importlib.machinery import ModuleSpec
+from typing import cast
+
 import cocotb
 import pytest
 
-from elasticai.creator.testing import (
-    eai_testbench,
-)
-
-pytest_plugins = "elasticai.creator.testing.cocotb_pytest"
+from elasticai.creator.file_generation.resource_utils import get_file_from_package
+from elasticai.creator.testing import CocotbTestFixture, eai_testbench
 
 
 @cocotb.test()
@@ -17,7 +17,23 @@ async def my_testbench(dut, x, input_data):
 
 @pytest.mark.simulation
 @pytest.mark.parametrize(["x"], [(i,) for i in (1, 2, 3)])
-def test_my_testbench(cocotb_test_fixture, x):
+def test_can_store_parameters_in_artifact_dir(
+    cocotb_test_fixture: CocotbTestFixture, x
+):
     additional_input_data = [1, 2]
     cocotb_test_fixture.write({"input_data": additional_input_data})
-    cocotb_test_fixture.run(params={"X": x}, defines={})
+    with get_file_from_package(
+        cast(str, cast(ModuleSpec, __spec__).parent), "../vhdl/my_testbench.vhd"
+    ) as p:
+        cocotb_test_fixture.set_srcs((p.absolute(),))
+        cocotb_test_fixture.set_top_module_name("my_testbench")
+        cocotb_test_fixture.run(params={"X": x}, defines={})
+
+
+@pytest.mark.simulation
+def test_can_add_srcs_from_package(cocotb_test_fixture: CocotbTestFixture):
+    x = 1
+    cocotb_test_fixture.write({"input_data": [1, 2], "x": x})
+    package = ".".join(__spec__.parent.split(".")[0:-1])
+    print(package)
+    cocotb_test_fixture.add_srcs_from_package(package, "vhdl/*.vhd")


### PR DESCRIPTION
Collection of src files from package was cumbersome due to
having to handle the context manager from importlib resources.
This CR outsources the task to the cocotb_test_fixture.
