### PR TITLE
feat(arithmetic): add int arithmetic protocol and int converter

### DIFF
--- a/src/elasticai/creator/arithmetic/__init__.py
+++ b/src/elasticai/creator/arithmetic/__init__.py
@@ -1,5 +1,13 @@
+from ._int_arithmetic import int_arithmetic
+from ._int_converter import int_converter
 from .fxp_arithmetic import FxpArithmetic as FxpArithmetic
 from .fxp_converter import FxpConverter as FxpConverter
 from .fxp_params import FxpParams as FxpParams
 
-__all__ = ["FxpParams", "FxpArithmetic", "FxpConverter"]
+__all__ = [
+    "FxpParams",
+    "FxpArithmetic",
+    "FxpConverter",
+    "int_arithmetic",
+    "int_converter",
+]

--- a/src/elasticai/creator/arithmetic/_int_arith_protocol.py
+++ b/src/elasticai/creator/arithmetic/_int_arith_protocol.py
@@ -1,0 +1,74 @@
+from typing import Protocol, TypeVar, overload
+
+from .fxp_params import ConvertableToFixedPointValues, FxpParams
+
+T = TypeVar("T", bound=ConvertableToFixedPointValues)
+
+
+class IntArithmetic(Protocol):
+    @property
+    def config(self) -> FxpParams: ...
+
+    @property
+    def total_bits(self) -> int: ...
+
+    def integer_out_of_bounds(self, number): ...
+
+    @property
+    def minimum_as_integer(self) -> int: ...
+
+    @property
+    def maximum_as_integer(self) -> int: ...
+
+    @overload
+    def cut_as_integer(self, number: float | int) -> int:
+        """Cutting the input number to integer directly (more like in hardware)"""
+        ...
+
+    @overload
+    def cut_as_integer(self, number: list) -> list:
+        """Cutting the input number to integer directly (more like in hardware)"""
+        ...
+
+    @overload
+    def cut_as_integer(self, number: T) -> T:
+        """Cutting the input number to integer directly (more like in hardware)"""
+        ...
+
+    @overload
+    def round_to_integer(self, number: float | int) -> int:
+        """Mathematical Round function for number"""
+        ...
+
+    @overload
+    def round_to_integer(self, number: T) -> T:
+        """Mathematical Round function for number"""
+        ...
+
+    @overload
+    def clamp(self, number: int) -> int: ...
+
+    @overload
+    def clamp(self, number: float) -> float: ...
+
+    @overload
+    def clamp(self, number: T) -> T: ...
+
+    @overload
+    def to_twos(self, number: int) -> int: ...
+
+    @overload
+    def to_twos(self, number: float) -> int: ...
+
+    @overload
+    def to_twos(self, number: T) -> T: ...
+
+    def to_twos(self, number: int | float | T) -> int | T: ...
+
+    @overload
+    def is_power_of_2(self, number: T) -> T: ...
+
+    @overload
+    def is_power_of_2(self, number: int) -> bool: ...
+
+    def is_power_of_2(self, number: int | T) -> bool | T: ...

--- a/src/elasticai/creator/arithmetic/_int_arithmetic.py
+++ b/src/elasticai/creator/arithmetic/_int_arithmetic.py
@@ -1,0 +1,7 @@
+from ._int_arith_protocol import IntArithmetic
+from .fxp_arithmetic import FxpArithmetic
+from .fxp_params import FxpParams
+
+
+def int_arithmetic(total_bits: int, signed: bool) -> IntArithmetic:
+    return FxpArithmetic(FxpParams(total_bits=total_bits, frac_bits=0, signed=signed))

--- a/src/elasticai/creator/arithmetic/_int_converter.py
+++ b/src/elasticai/creator/arithmetic/_int_converter.py
@@ -1,0 +1,25 @@
+from typing import Protocol
+
+from .fxp_converter import FxpConverter
+from .fxp_params import FxpParams
+
+
+def int_converter(total_bits: int, signed: bool) -> "IntConverter":
+    return FxpConverter(FxpParams(total_bits=total_bits, frac_bits=0, signed=signed))
+
+
+class IntConverter(Protocol):
+    @property
+    def total_bits(self) -> int: ...
+
+    def integer_to_binary_string_vhdl(self, number: int) -> str: ...
+
+    def integer_to_hex_string_vhdl(self, number: int) -> str: ...
+
+    def integer_to_binary_string_verilog(self, number: int) -> str: ...
+
+    def integer_to_decimal_string_verilog(self, number: int) -> str: ...
+
+    def integer_to_hex_string_verilog(self, number: int) -> str: ...
+
+    def binary_to_integer(self, binary: str) -> int: ...

--- a/src/elasticai/creator/arithmetic/fxp_arithmetic.py
+++ b/src/elasticai/creator/arithmetic/fxp_arithmetic.py
@@ -2,6 +2,7 @@ import warnings
 from dataclasses import dataclass
 from typing import Any, TypeVar, cast, overload
 
+from ._int_arith_protocol import IntArithmetic
 from .fxp_params import (
     ConvertableToFixedPointValues,
     FxpParams,
@@ -11,7 +12,7 @@ T = TypeVar("T", bound="ConvertableToFixedPointValues")
 
 
 @dataclass
-class FxpArithmetic:
+class FxpArithmetic(IntArithmetic):
     def __init__(self, fxp_params: FxpParams):
         self._config = fxp_params
 

--- a/tests/unit_tests/arithmetic/fxp_conversion_test.py
+++ b/tests/unit_tests/arithmetic/fxp_conversion_test.py
@@ -1,3 +1,5 @@
+from itertools import chain
+
 import pytest
 from hypothesis import given, settings, strategies
 
@@ -5,22 +7,40 @@ from elasticai.creator.arithmetic.fxp_converter import FxpConverter, FxpParams
 
 
 @pytest.mark.parametrize(
-    "total_bits, frac_bits, number, check",
-    [
-        (2, 0, 1, '"01"'),
-        (2, 1, -1, '"11"'),
-        (4, 2, 1, '"0001"'),
-        (4, 2, -1, '"1111"'),
-        (4, 2, -3, '"1101"'),
-        (8, 4, -98, '"10011110"'),
-        (8, 4, 35, '"00100011"'),
-    ],
+    "total_bits, frac_bits, signed, number, check",
+    list(
+        chain(
+            [
+                (total, frac, True, number, check)
+                for total, frac, number, check in [
+                    (2, 0, 1, '"01"'),
+                    (2, 1, -1, '"11"'),
+                    (4, 2, 1, '"0001"'),
+                    (4, 2, -1, '"1111"'),
+                    (4, 2, -3, '"1101"'),
+                    (8, 4, -98, '"10011110"'),
+                    (8, 4, 35, '"00100011"'),
+                ]
+            ],
+            [
+                (total, frac, False, number, check)
+                for total, frac, number, check in [
+                    (2, 0, 3, '"11"'),
+                    (4, 0, 1, '"0001"'),
+                    (4, 0, 15, '"1111"'),
+                    (4, 0, 13, '"1101"'),
+                    (8, 0, 165, '"10100101"'),
+                    (8, 0, 35, '"00100011"'),
+                ]
+            ],
+        )
+    ),
 )
 def test_convert_integer_to_binary_vhdl(
-    total_bits: int, frac_bits: int, number: int, check: str
+    total_bits: int, frac_bits: int, signed: bool, number: int, check: str
 ):
     rslt = FxpConverter(
-        FxpParams(total_bits=total_bits, frac_bits=frac_bits, signed=True)
+        FxpParams(total_bits=total_bits, frac_bits=frac_bits, signed=signed)
     ).integer_to_binary_string_vhdl(number)
     assert rslt == check
 
@@ -42,6 +62,25 @@ def test_convert_integer_to_hex_vhdl(
 ):
     rslt = FxpConverter(
         FxpParams(total_bits=total_bits, frac_bits=frac_bits)
+    ).integer_to_hex_string_vhdl(number)
+    assert rslt == check
+
+
+@pytest.mark.parametrize(
+    "total_bits, frac_bits, number, check",
+    [
+        (4, 0, 1, 'X"1"'),
+        (4, 0, 15, 'X"F"'),
+        (4, 0, 3, 'X"3"'),
+        (8, 0, 99, 'X"63"'),
+        (8, 0, 35, 'X"23"'),
+    ],
+)
+def test_convert_unsigned_int_to_hex_vhdl(
+    total_bits: int, frac_bits: int, number: int, check: str
+):
+    rslt = FxpConverter(
+        FxpParams(total_bits=total_bits, frac_bits=frac_bits, signed=False)
     ).integer_to_hex_string_vhdl(number)
     assert rslt == check
 
@@ -227,6 +266,8 @@ def test_convert_rational_to_hex_verilog(
         (4, 2, True, "1101", -3),
         (8, 4, True, "10110110", -74),
         (8, 4, True, "00100110", 38),
+        (2, 1, False, "11", 3),
+        (2, 0, True, "10", -2),
     ],
 )
 def test_convert_binary_vhdl_to_integer(

--- a/tests/unit_tests/arithmetic/int_conversion_test.py
+++ b/tests/unit_tests/arithmetic/int_conversion_test.py
@@ -1,0 +1,192 @@
+from random import randint
+
+import pytest
+
+from elasticai.creator.arithmetic._int_converter import int_converter
+from elasticai.creator.arithmetic.fxp_params import FxpParams
+
+
+@pytest.mark.parametrize(
+    "total_bits, is_signed, number, check",
+    [
+        (2, True, 1, '"01"'),
+        (2, True, -1, '"11"'),
+        (4, True, 1, '"0001"'),
+        (4, True, -1, '"1111"'),
+        (4, True, -3, '"1101"'),
+        (8, True, -98, '"10011110"'),
+        (8, True, 35, '"00100011"'),
+        (2, False, 1, '"01"'),
+        (2, False, 3, '"11"'),
+        (4, False, 1, '"0001"'),
+        (4, False, 15, '"1111"'),
+        (4, False, 13, '"1101"'),
+        (8, False, 165, '"10100101"'),
+        (8, False, 35, '"00100011"'),
+    ],
+)
+def test_convert_integer_to_binary_vhdl(
+    total_bits: int, is_signed: bool, number: int, check: str
+):
+    rslt = int_converter(
+        total_bits=total_bits, signed=is_signed
+    ).integer_to_binary_string_vhdl(number)
+    assert rslt == check
+
+
+@pytest.mark.parametrize(
+    "total_bits, is_signed, number, check",
+    [
+        (2, True, 1, 'X"1"'),
+        (2, True, -1, 'X"3"'),
+        (4, True, 1, 'X"1"'),
+        (4, True, -1, 'X"F"'),
+        (4, True, -3, 'X"D"'),
+        (8, True, -99, 'X"9D"'),
+        (8, True, 35, 'X"23"'),
+        (2, False, 1, 'X"1"'),
+        (2, False, 3, 'X"3"'),
+        (4, False, 1, 'X"1"'),
+        (4, False, 15, 'X"F"'),
+        (4, False, 3, 'X"3"'),
+        (8, False, 99, 'X"63"'),
+        (8, False, 35, 'X"23"'),
+    ],
+)
+def test_convert_integer_to_hex_vhdl(
+    total_bits: int, is_signed: bool, number: int, check: str
+):
+    rslt = int_converter(
+        total_bits=total_bits, signed=is_signed
+    ).integer_to_hex_string_vhdl(number)
+    assert rslt == check
+
+
+@pytest.mark.parametrize(
+    "total_bits, is_signed, number, check",
+    [
+        (2, 0, 1, "2'b01"),
+        (2, 1, -1, "2'b11"),
+        (4, 2, 1, "4'b0001"),
+        (4, 2, -1, "4'b1111"),
+        (4, 2, -3, "4'b1101"),
+        (8, 4, 103, "8'b01100111"),
+        (8, 6, -7, "8'b11111001"),
+    ],
+)
+def test_convert_integer_to_binary_verilog(
+    total_bits: int, is_signed: bool, number: int, check: str
+):
+    rslt = int_converter(
+        total_bits=total_bits, signed=is_signed
+    ).integer_to_binary_string_verilog(number)
+    assert rslt == check
+
+
+@pytest.mark.parametrize(
+    "total_bits, is_signed, number, check",
+    [
+        (2, 0, 1, "2'd1"),
+        (2, 1, -1, "2'd3"),
+        (4, 2, 1, "4'd1"),
+        (4, 2, -1, "4'd15"),
+        (4, 2, -3, "4'd13"),
+        (8, 4, -101, "8'd155"),
+        (8, 4, 35, "8'd35"),
+    ],
+)
+def test_convert_integer_to_decimal_verilog(
+    total_bits: int, is_signed: bool, number: int, check: str
+):
+    rslt = int_converter(
+        total_bits=total_bits, signed=is_signed
+    ).integer_to_decimal_string_verilog(number)
+    assert rslt == check
+
+
+@pytest.mark.parametrize(
+    "total_bits, is_signed, number, check",
+    [
+        (2, 0, 1, "2'h1"),
+        (2, 1, -1, "2'h3"),
+        (4, 2, 1, "4'h1"),
+        (4, 2, -1, "4'hF"),
+        (4, 2, -3, "4'hD"),
+        (8, 4, -101, "8'h9B"),
+        (8, 4, 35, "8'h23"),
+    ],
+)
+def test_convert_integer_to_hex_verilog(
+    total_bits: int, is_signed: bool, number: int, check: str
+):
+    rslt = int_converter(
+        total_bits=total_bits, signed=is_signed
+    ).integer_to_hex_string_verilog(number)
+    assert rslt == check
+
+
+@pytest.mark.parametrize(
+    "total_bits, is_signed, number, expected",
+    [
+        (2, True, "01", 1),
+        (2, False, "11", 3),
+        (2, True, "10", -2),
+        (4, True, "0100", 4),
+        (4, True, "1100", -4),
+        (4, True, "1100", -4),
+        (4, False, "1100", 12),
+        (4, True, "1101", -3),
+        (8, True, "10110110", -74),
+        (8, True, "00100110", 38),
+    ],
+)
+def test_convert_binary_vhdl_to_integer(
+    total_bits: int, is_signed: bool, number: str, expected: str
+):
+    rslt = int_converter(total_bits=total_bits, signed=is_signed).binary_to_integer(
+        number
+    )
+    assert rslt == expected
+
+
+@pytest.mark.parametrize(
+    "total_bits, is_signed, number, expected",
+    [
+        (2, True, "01", 1),
+        (2, True, "'b01", 1),
+        (2, True, "2'b01", 1),
+        (2, False, "11", 3),
+        (2, False, "'b11", 3),
+        (2, False, "2'b11", 3),
+        (8, True, "10110110", -74),
+        (8, True, "'b10110110", -74),
+        (8, True, "8'b10110110", -74),
+        (8, False, "00100110", 38),
+        (8, False, "'b00100110", 38),
+        (8, False, "8'b00100110", 38),
+    ],
+)
+def test_convert_binary_string_to_integer(
+    total_bits: int, is_signed: bool, number: str, expected: str
+):
+    rslt = int_converter(total_bits=total_bits, signed=is_signed).binary_to_integer(
+        number
+    )
+    assert rslt == expected
+
+
+@pytest.mark.parametrize("total_bits", [2, 4, 8, 16])
+@pytest.mark.parametrize("is_signed", [False, True])
+def test_convert_binary_string_to_integer_back(total_bits: int, is_signed: bool):
+    sets = FxpParams(total_bits=total_bits, frac_bits=0, signed=is_signed)
+    config = int_converter(total_bits=total_bits, signed=is_signed)
+
+    for _ in range(8):
+        val = randint(a=sets.minimum_as_integer, b=sets.maximum_as_integer)
+        bin_vhdl_out = config.integer_to_binary_string_vhdl(val)
+        val_vhdl_out = config.binary_to_integer(bin_vhdl_out)
+        assert val == val_vhdl_out
+
+        bin_verilog_out = config.integer_to_binary_string_verilog(val)
+        val_verilog_out = config.binary_to_integer(bin_verilog_out)
+        assert val == val_verilog_out


### PR DESCRIPTION
Clients should use the int arithmetics returned by the epynomous
function from the arithmetic module when dealing with integers
instead of fixed point numbers.

Implementation delegates to fxp arithmetics.

fix: Increased testcases for FxpConverter and removed non-tested hex/dec string to number conversion (not tested, not used and wrong)

fix(arithmetic): Changed test for checking of integer/rational is out-of-range

feat(arithmetic): Add clamp func to FxpArithmetic

feat(arithmetic): Add Integer Dataclass for Params, Arithmetic and Converter (mostly similar to Fxp*)

feat(arithmetic): Add new supporting funcs for absolute calculation and tensor type checking
