### PR TITLE
feat(ir): ease creation of and conversion between new ir variants

### DIFF
--- a/plugins/lutron_filter/src/elasticai/creator_plugins/lutron_filter/rules/_ir.py
+++ b/plugins/lutron_filter/src/elasticai/creator_plugins/lutron_filter/rules/_ir.py
@@ -14,6 +14,7 @@ from elasticai.creator.ir import (
     PatternRule,
     PatternRuleSpec,
     Rule,
+    StdIrFactory,
     attribute,
 )
 from elasticai.creator.ir import DataGraph as _BaseDataGraph
@@ -23,9 +24,7 @@ from elasticai.creator.ir import (
 from elasticai.creator.ir import (
     EdgeImpl as _EdgeImpl,
 )
-from elasticai.creator.ir import GraphImpl as _GraphImpl
 from elasticai.creator.ir import Node as _Node
-from elasticai.creator.ir import NodeEdgeFactory as _NodeEdgeFactory
 from elasticai.creator.ir import (
     NodeImpl as _NodeImpl,
 )
@@ -168,25 +167,16 @@ class FilterDecorator[T: Decoratable]:
         return self.__cached_filter_params
 
 
-class NodeEdgeFactory(_NodeEdgeFactory[Node, Edge]):
-    def edge(
-        self, src: str, dst: str, attributes: AttributeMapping = AttributeMapping(), /
-    ) -> Edge:
-        return _EdgeImpl(src, dst, attributes)
+class _IrFactory(StdIrFactory[Node, Edge, DataGraph]):
+    def __init__(self):
+        super().__init__(Node, _EdgeImpl, _DataGraphImpl)
 
-    def node(
-        self, name: str, attributes: AttributeMapping = AttributeMapping(), /
-    ) -> Node:
-        return Node(name, attributes)
+
+ir_factory: IrFactory[Node, Edge, DataGraph] = _IrFactory()
 
 
 def wrap_graph(g: _BaseDataGraph[_Node, Edge]) -> _DataGraph[Node, Edge]:
-    return _DataGraphImpl(
-        factory=NodeEdgeFactory(),
-        attributes=g.attributes,
-        graph=g.graph,
-        node_attributes=g.node_attributes,
-    )
+    return ir_factory.graph_from_other(g)
 
 
 def wrap_node(n: _Node) -> Node:
@@ -195,19 +185,6 @@ def wrap_node(n: _Node) -> Node:
 
 def wrap_registry(reg: Registry) -> Registry[DataGraph]:
     return ir.Registry((name, wrap_graph(g)) for name, g in reg.items())
-
-
-class _IrFactory(NodeEdgeFactory):
-    def graph(self, attributes: AttributeMapping = AttributeMapping(), /) -> DataGraph:
-        return _DataGraphImpl(
-            factory=self,
-            attributes=attributes,
-            node_attributes=AttributeMapping(),
-            graph=_GraphImpl(lambda: AttributeMapping()),
-        )
-
-
-ir_factory: IrFactory[Node, Edge, DataGraph] = _IrFactory()
 
 
 def serialize(g: DataGraph) -> dict:

--- a/src/elasticai/creator/experimental/ir/shape_inference/shape_inference.py
+++ b/src/elasticai/creator/experimental/ir/shape_inference/shape_inference.py
@@ -4,7 +4,7 @@ from typing import Any, Iterable, Protocol, cast
 import elasticai.creator.function_dispatch as FD
 from elasticai.creator import ir
 from elasticai.creator.graph import bfs_iter_down
-from elasticai.creator.ir import AttributeMapping, Graph, GraphImpl
+from elasticai.creator.ir2torch.ir2torch import _DataGraph
 
 type DataGraph = ir.DataGraph[ir.Node, ir.Edge]
 type Registry = ir.Registry[DataGraph]
@@ -205,38 +205,8 @@ class _ShapedEdgeImpl(ir.EdgeImpl):
         return _guard_shape(self.attributes["shape"])
 
 
-class _NodeEdgeFactory(ir.StdNodeEdgeFactory):
+class IrFactory(ir.StdIrFactory):
     def __init__(self):
-        super().__init__(node_fn=_NodeImpl, edge_fn=_ShapedEdgeImpl)
-
-
-class IrFactory(ir.IrFactory):
-    def __init__(self):
-        self._node_edge_fact = _NodeEdgeFactory()
-
-    def node(self, name: str, attributes: AttributeMapping = ir.attribute(), /) -> Node:
-        return self._node_edge_fact.node(name, attributes)
-
-    def edge(
-        self, src: str, dst: str, attributes: AttributeMapping = ir.attribute(), /
-    ) -> ShapedEdge:
-        return self._node_edge_fact.edge(src, dst, attributes)
-
-    def graph(
-        self,
-        attributes: AttributeMapping = ir.attribute(),
-        /,
-        other: ir.DataGraph[ir.Node, ir.Edge] | None = None,
-    ) -> ShapedDatagraph:
-        node_attributes = ir.attribute()
-        graph: Graph[str, AttributeMapping] = GraphImpl(lambda: AttributeMapping())
-        if other is not None:
-            node_attributes = other.node_attributes
-            graph = other.graph
-            attributes = other.attributes | attributes
-        return ir.DataGraphImpl(
-            node_attributes=node_attributes,
-            attributes=attributes,
-            graph=graph,
-            factory=ir.StdNodeEdgeFactory(_NodeImpl, _ShapedEdgeImpl),
+        super().__init__(
+            node_fn=_NodeImpl, edge_fn=_ShapedEdgeImpl, graph_fn=_DataGraph
         )

--- a/src/elasticai/creator/hdl_ir.py
+++ b/src/elasticai/creator/hdl_ir.py
@@ -245,7 +245,12 @@ class IrFactory:
         if name is not None:
             attributes = attributes.new_with(name=name)
 
-        return DataGraphImpl(self, attributes, _graph, node_attributes)
+        return DataGraphImpl(
+            factory=self,
+            attributes=attributes,
+            graph=_graph,
+            node_attributes=node_attributes,
+        )
 
 
 def _check_and_get_name_fn(name: str | None, fn: Callable) -> str:

--- a/src/elasticai/creator/ir/__init__.py
+++ b/src/elasticai/creator/ir/__init__.py
@@ -2,7 +2,6 @@ from ._attribute import Attribute, AttributeConvertable, AttributeMapping, attri
 from .datagraph import DataGraph, Edge, Node, NodeEdgeFactory, ReadOnlyDataGraph
 from .datagraph_impl import (
     DataGraphImpl,
-    DefaultDataGraphFactory,
     DefaultIrFactory,
     DefaultNodeEdgeFactory,
     EdgeImpl,
@@ -10,7 +9,7 @@ from .datagraph_impl import (
 )
 from .datagraph_rewriting import Pattern, PatternRule, PatternRuleSpec, Rule, StdPattern
 from .deserializer import IrDeserializer, IrDeserializerLegacy
-from .factories import IrFactory, StdDataGraphFactory, StdIrFactory, StdNodeEdgeFactory
+from .factories import IrFactory, StdIrFactory
 from .graph import Graph, GraphImpl
 from .registry import Registry
 from .serializer import IrSerializer, IrSerializerLegacy
@@ -20,7 +19,6 @@ __all__ = [
     "AttributeConvertable",
     "AttributeMapping",
     "attribute",
-    "DefaultDataGraphFactory",
     "DefaultIrFactory",
     "DefaultNodeEdgeFactory",
     "DataGraphImpl",
@@ -28,10 +26,8 @@ __all__ = [
     "GraphImpl",
     "EdgeImpl",
     "IrFactory",
-    "StdNodeEdgeFactory",
-    "NodeImpl",
-    "StdDataGraphFactory",
     "StdIrFactory",
+    "NodeImpl",
     "DataGraph",
     "Edge",
     "Node",

--- a/src/elasticai/creator/ir/datagraph.py
+++ b/src/elasticai/creator/ir/datagraph.py
@@ -81,6 +81,7 @@ class ReadOnlyDataGraph(ReadOnlyGraph[str, AttributeMapping], Protocol[N, E]):
     def edges(self) -> Mapping[tuple[str, str], E]: ...
 
 
+@runtime_checkable
 class DataGraph(ReadOnlyDataGraph[N, E], Graph[str, AttributeMapping], Protocol[N, E]):
     """
     Note that the fact, that `add_node` and similar methods take
@@ -133,6 +134,15 @@ class DataGraph(ReadOnlyDataGraph[N, E], Graph[str, AttributeMapping], Protocol[
 
     @abstractmethod
     def with_attributes(self, attributes: AttributeMapping) -> Self: ...
+
+    @abstractmethod
+    def with_data_from(self, other: ReadOnlyDataGraph) -> Self:
+        """Construct a new graph with underlying data from other.
+        Note: Involves only shallow copies and
+          is cheaper than adding nodes/edges
+          one by one.
+        """
+        ...
 
     @abstractmethod
     def clear(self) -> Self:

--- a/src/elasticai/creator/ir/datagraph_impl.py
+++ b/src/elasticai/creator/ir/datagraph_impl.py
@@ -6,10 +6,9 @@ from collections.abc import (
 from typing import Self
 
 from ._attribute import AttributeMapping
-from .datagraph import DataGraph, Edge, Node
+from .datagraph import DataGraph, Edge, Node, ReadOnlyDataGraph
 from .factories import (
     NodeEdgeFactory,
-    StdDataGraphFactory,
     StdIrFactory,
 )
 from .graph import Graph, GraphImpl
@@ -161,6 +160,7 @@ class DataGraphImpl[N: Node, E: Edge](DataGraph[N, E]):
     def __init__(
         self,
         /,
+        *,
         factory: NodeEdgeFactory[N, E],
         attributes: AttributeMapping,
         graph: Graph[str, AttributeMapping],
@@ -366,6 +366,13 @@ class DataGraphImpl[N: Node, E: Edge](DataGraph[N, E]):
             node_attributes=node_attributes,
         )
 
+    def with_data_from(self, other: ReadOnlyDataGraph) -> Self:
+        return self._new(
+            attributes=other.attributes,
+            graph=other.graph,
+            node_attributes=other.node_attributes,
+        )
+
     def __repr__(self) -> str:
         return f"DataGraphImpl(node_attributes={repr(self.node_attributes)}, attributes={repr(self.attributes)}, edges={repr(self._graph.successors)})"
 
@@ -383,18 +390,13 @@ def _new_graph[N: Node, E: Edge](
     factory: NodeEdgeFactory[N, E], attributes
 ) -> DataGraph[N, E]:
     return DataGraphImpl(
-        factory,
-        attributes,
-        GraphImpl(lambda: AttributeMapping()),
-        AttributeMapping(),
+        factory=factory,
+        attributes=attributes,
+        graph=GraphImpl(lambda: AttributeMapping()),
+        node_attributes=AttributeMapping(),
     )
-
-
-class DefaultDataGraphFactory[N: Node, E: Edge](StdDataGraphFactory[N, E, DataGraph]):
-    def __init__(self, node_edge_factory: NodeEdgeFactory[N, E]) -> None:
-        super().__init__(node_edge_factory, _new_graph)
 
 
 class DefaultIrFactory(StdIrFactory[Node, Edge, DataGraph[Node, Edge]]):
     def __init__(self) -> None:
-        super().__init__(NodeImpl, EdgeImpl, _new_graph)
+        super().__init__(NodeImpl, EdgeImpl, DataGraphImpl)

--- a/src/elasticai/creator/ir/factories.py
+++ b/src/elasticai/creator/ir/factories.py
@@ -1,11 +1,13 @@
 from abc import abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Mapping
 from typing import Protocol
 
 from ._attribute import AttributeMapping
-from .datagraph import DataGraph, NodeEdgeFactory
+from .datagraph import DataGraph, Graph, NodeEdgeFactory, ReadOnlyDataGraph
 from .datagraph import Edge as _Edge
 from .datagraph import Node as _Node
+from .graph import GraphImpl
+from .registry import Registry
 
 
 class StdNodeEdgeFactory[N: _Node, E: _Edge](NodeEdgeFactory):
@@ -26,43 +28,117 @@ class StdNodeEdgeFactory[N: _Node, E: _Edge](NodeEdgeFactory):
         return self._edge_fn(src, dst, attributes)
 
 
-class DataGraphFactory[G: DataGraph](Protocol):
-    def graph(self, attributes: AttributeMapping = AttributeMapping(), /) -> G: ...
+class IrFactory[N: _Node, E: _Edge, G: DataGraph](NodeEdgeFactory[N, E], Protocol):
+    @abstractmethod
+    def node_from_other(self, other: _Node) -> N:
+        return self.node(other.name, other.attributes)
+
+    @abstractmethod
+    def edge_from_other(self, other: _Edge) -> E:
+        return self.edge(other.src, other.dst, other.attributes)
+
+    @abstractmethod
+    def graph(
+        self,
+        attributes: AttributeMapping = AttributeMapping(),
+    ) -> G: ...
+
+    @abstractmethod
+    def graph_from_other(self, other: ReadOnlyDataGraph) -> G: ...
+
+    @abstractmethod
+    def registry(
+        self,
+        items: Mapping[str, DataGraph] | Iterable[tuple[str, DataGraph]] | None = None,
+    ) -> Registry[G]: ...
 
 
-class StdDataGraphFactory[N: _Node, E: _Edge, G: DataGraph](DataGraphFactory[G]):
+class _GraphConstructorMethod[G: DataGraph](Protocol):
+    def __call__(
+        self,
+        /,
+        *,
+        factory: NodeEdgeFactory,
+        attributes: AttributeMapping,
+        graph: Graph[str, AttributeMapping],
+        node_attributes: AttributeMapping,
+    ) -> G: ...
+
+
+class _GraphConstructorFn[G: DataGraph](Protocol):
+    @staticmethod
+    def __call__(
+        *,
+        factory: NodeEdgeFactory,
+        attributes: AttributeMapping,
+        graph: Graph[str, AttributeMapping],
+        node_attributes: AttributeMapping,
+    ) -> G: ...
+
+
+type _GraphConstructor[G: DataGraph] = (
+    _GraphConstructorFn[G] | _GraphConstructorMethod[G]
+)
+
+
+class StdIrFactory[N: _Node, E: _Edge, G: DataGraph](IrFactory[N, E, G]):
     def __init__(
         self,
-        node_edge: NodeEdgeFactory[N, E],
-        graph_fn: Callable[[NodeEdgeFactory[N, E], AttributeMapping], G],
-    ):
-        self._node_edge = node_edge
-        self._graph_fn = graph_fn
+        node_fn: Callable[[str, AttributeMapping], N],
+        edge_fn: Callable[[str, str, AttributeMapping], E],
+        graph_fn: _GraphConstructor[G],
+    ) -> None:
+        self._node = node_fn
+        self._edge = edge_fn
+        self._graph = graph_fn
+
+    def registry(
+        self,
+        items: Mapping[str, DataGraph] | Iterable[tuple[str, DataGraph]] | None = None,
+    ) -> Registry[G]:
+        if items is None:
+            return Registry()
+        reg = Registry(items)
+        return reg.apply(lambda g: self.graph_from_other(other=g))
+
+    def node(
+        self,
+        name: str,
+        attributes: AttributeMapping = AttributeMapping(),
+    ) -> N:
+        return self._node(name, attributes)
+
+    def node_from_other(self, other: _Node) -> N:
+        return self._node(other.name, other.attributes)
+
+    def edge(
+        self,
+        src: str,
+        dst: str,
+        attributes: AttributeMapping = AttributeMapping(),
+    ) -> E:
+        return self._edge(src, dst, attributes)
+
+    def edge_from_other(self, other: _Edge) -> E:
+        return self._edge(other.src, other.dst, other.attributes)
 
     def graph(
         self,
         attributes: AttributeMapping = AttributeMapping(),
     ) -> G:
-        return self._graph_fn(
-            self._node_edge,
-            attributes,
+        """create a new graph using the underlying data from other"""
+        empty_attributes = AttributeMapping()
+        return self._graph(
+            factory=self,
+            attributes=attributes,
+            graph=GraphImpl(lambda: empty_attributes),
+            node_attributes=empty_attributes,
         )
 
-
-class IrFactory[N: _Node, E: _Edge, G: DataGraph](NodeEdgeFactory[N, E], Protocol):
-    @abstractmethod
-    def graph(self, attributes: AttributeMapping = AttributeMapping(), /) -> G: ...
-
-
-class StdIrFactory[N: _Node, E: _Edge, G: DataGraph](StdNodeEdgeFactory[N, E]):
-    def __init__(
-        self,
-        node_fn: Callable[[str, AttributeMapping], N],
-        edge_fn: Callable[[str, str, AttributeMapping], E],
-        graph_fn: Callable[[NodeEdgeFactory[N, E], AttributeMapping], G],
-    ) -> None:
-        super().__init__(node_fn, edge_fn)
-        self._graph = StdDataGraphFactory(self, graph_fn)
-
-    def graph(self, attributes: AttributeMapping = AttributeMapping()) -> G:
-        return self._graph.graph(attributes)
+    def graph_from_other(self, other: ReadOnlyDataGraph) -> G:
+        return self._graph(
+            factory=self,
+            attributes=other.attributes,
+            graph=other.graph,
+            node_attributes=other.node_attributes,
+        )

--- a/src/elasticai/creator/ir/registry.py
+++ b/src/elasticai/creator/ir/registry.py
@@ -1,5 +1,5 @@
-from collections.abc import Iterable, Iterator, Mapping
-from typing import Any, Self, overload
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from typing import Any, Self, cast, overload
 
 from .datagraph import DataGraph
 
@@ -38,7 +38,7 @@ class Registry[G: DataGraph](Mapping[str, G]):
             self._data = dict(items)
 
     def __getitem__(self, name: str) -> G:
-        return self._data[name]
+        return cast(G, self._data[name])
 
     def __len__(self) -> int:
         return len(self._data)
@@ -56,6 +56,10 @@ class Registry[G: DataGraph](Mapping[str, G]):
 
     def add(self, name: str, graph: G) -> Self:
         return type(self)(**(self._data) | {name: graph})
+
+    def apply[G2: DataGraph](self, fn: Callable[[G], G2]) -> "Registry[G2]":
+        new_dict = ((k, fn(g)) for k, g in self._data.items())
+        return Registry(new_dict)
 
     def __repr__(self) -> str:
         return f"Registry(**{repr(self._data)})"

--- a/src/elasticai/creator/ir2torch/ir2torch.py
+++ b/src/elasticai/creator/ir2torch/ir2torch.py
@@ -8,6 +8,7 @@ from torch import fx
 
 import elasticai.creator.function_dispatch as FD
 from elasticai.creator import ir
+from elasticai.creator.ir import StdIrFactory
 
 from .default_handlers import dgraph_handlers, node_handlers
 
@@ -26,54 +27,9 @@ class _DataGraph(ir.DataGraphImpl[ir.Node, ir.Edge]):
         return result
 
 
-def _new_graph(
-    factory: ir.NodeEdgeFactory[ir.Node, ir.Edge], attributes: ir.AttributeMapping
-) -> DataGraph:
-    return _DataGraph(
-        factory,
-        attributes,
-        ir.GraphImpl(lambda: ir.AttributeMapping()),
-        ir.AttributeMapping(),
-    )
-
-
-class IrFactory(ir.IrFactory[ir.Node, ir.Edge, ir.DataGraph]):
-    def __init__(self):
-        self._node_edge = ir.DefaultNodeEdgeFactory()
-
-        def graph(attributes):
-            return _new_graph(self, attributes)
-
-        self._graph = graph
-
-    def node(
-        self, name: str, attributes: ir.AttributeMapping = ir.AttributeMapping()
-    ) -> ir.Node:
-        return self._node_edge.node(name, attributes)
-
-    def edge(
-        self,
-        src: str,
-        dst: str,
-        attributes: ir.AttributeMapping = ir.AttributeMapping(),
-    ) -> ir.Edge:
-        return self._node_edge.edge(src, dst, attributes)
-
-    def graph(
-        self,
-        attributes: ir.AttributeMapping = ir.AttributeMapping(),
-        /,
-        *,
-        graph: ir.DataGraph | None = None,
-    ) -> DataGraph:
-        if graph is not None:
-            return _DataGraph(
-                factory=self,
-                attributes=graph.attributes,
-                graph=graph.graph,
-                node_attributes=graph.node_attributes,
-            )
-        return self._graph(attributes)
+class IrFactory(StdIrFactory[ir.Node, ir.Edge, DataGraph]):
+    def __init__(self) -> None:
+        super().__init__(ir.NodeImpl, ir.EdgeImpl, _DataGraph)
 
 
 type TypeHandler = Callable[[DataGraph], nn.Module]
@@ -167,7 +123,7 @@ class Ir2Torch:
         root_module = nn.Module()
 
         def to_new_graph(name, graph):
-            return name, factory.graph(graph=graph)
+            return name, factory.graph_from_other(graph)
 
         for name, impl in starmap(to_new_graph, registry.items()):
             layer = self._build_submodule(impl)

--- a/tests/unit_tests/ir/datagraph_test.py
+++ b/tests/unit_tests/ir/datagraph_test.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any, Protocol, cast
+from typing import Any, cast
 
 import pytest
 
@@ -9,7 +9,6 @@ from elasticai.creator.ir import Attribute, AttributeMapping, Edge, Node
 from elasticai.creator.ir.datagraph import DataGraph
 from elasticai.creator.ir.datagraph_impl import (
     DataGraphImpl,
-    DefaultDataGraphFactory,
     DefaultIrFactory,
     DefaultNodeEdgeFactory,
     EdgeImpl,
@@ -19,6 +18,7 @@ from elasticai.creator.ir.deserializer import IrDeserializer
 from elasticai.creator.ir.factories import (
     IrFactory,
     NodeEdgeFactory,
+    StdIrFactory,
     StdNodeEdgeFactory,
 )
 from elasticai.creator.ir.graph import GraphImpl
@@ -313,59 +313,6 @@ class TestSerialization:
         assert g == deserialized
 
 
-def test_dynamically_extend_nodes_and_graphs_in_custom_factory() -> None:
-    class MyNode(Node, Protocol):
-        @property
-        def implementation(self) -> str: ...
-
-    class MyGraph(dgraph.DataGraph[MyNode, dgraph.Edge], Protocol):
-        @property
-        def name(self) -> str: ...
-
-    class MyIrFactory(IrFactory):
-        def __init__(self):
-            self._node_edge = DefaultNodeEdgeFactory()
-            self._graph = DefaultDataGraphFactory(self)
-
-        def node(
-            self, name: str, attributes: AttributeMapping = AttributeMapping()
-        ) -> MyNode:
-            n = self._node_edge.node(name, attributes)
-
-            class _Node(n.__class__):  # type: ignore
-                @property
-                def implementation(self) -> str:
-                    return self.attributes.get("implementation", "<none>")
-
-            n.__class__ = _Node
-            return cast(MyNode, n)
-
-        def edge(
-            self,
-            src: str,
-            dst: str,
-            attributes: AttributeMapping = AttributeMapping(),
-        ) -> Edge:
-            return self._node_edge.edge(src, dst, attributes)
-
-        def graph(self, attributes: AttributeMapping = AttributeMapping()) -> MyGraph:
-            g = self._graph.graph(attributes)
-
-            class _Graph(g.__class__):  # type: ignore
-                @property
-                def name(self) -> str:
-                    return self.attributes.get("name", "<undefined>")
-
-            g.__class__ = _Graph
-            return cast(MyGraph, g)
-
-    factory = MyIrFactory()
-    n = factory.node("x")
-    g = factory.graph()
-    assert n.implementation == "<none>"
-    assert g.name == "<undefined>"
-
-
 def test_extend_node_and_graph_statically() -> None:
     class MyNode(NodeImpl):
         @property
@@ -377,28 +324,9 @@ def test_extend_node_and_graph_statically() -> None:
         def name(self) -> str:
             return cast(str, self.attributes.get("name", "<undefined>"))
 
-    class MyFactory(IrFactory):
-        def node(
-            self, name: str, attributes: AttributeMapping = AttributeMapping()
-        ) -> MyNode:
-            return MyNode(name, attributes)
-
-        def edge(
-            self, src: str, dst: str, attributes: AttributeMapping = AttributeMapping()
-        ) -> Edge:
-            return EdgeImpl(src, dst, attributes)
-
-        def graph(
-            self, attributes: AttributeMapping = AttributeMapping()
-        ) -> MyGraph[MyNode, Edge]:
-            return MyGraph(
-                factory=self,
-                attributes=attributes,
-                graph=GraphImpl(
-                    lambda: AttributeMapping(),
-                ),
-                node_attributes=AttributeMapping(),
-            )
+    class MyFactory(StdIrFactory[MyNode, Edge, MyGraph]):
+        def __init__(self):
+            super().__init__(MyNode, EdgeImpl, MyGraph)
 
     f = MyFactory()
     n = f.node("x")

--- a/ty_config_for_ci.toml
+++ b/ty_config_for_ci.toml
@@ -11,6 +11,7 @@ include = [
   "src/elasticai/creator/hw_function_id.py",
   # "src/elasticai/creator/graph",
   "src/elasticai/creator/plugin",
+  "src/elasticai/creator/ir",
   "src/elasticai/creator/testing",
   "src/elasticai/creator_plugins",
   "src/elasticai/creator/experimental",


### PR DESCRIPTION
There are many different scenarios in which we want to easily
inject new datagraph and registry subtypes, convert between
them. E.g., adding an additional field to each node in a
datagraph that should afterwards be accessible via a property
or supporting creation of new datagraphs in functions generic
over a datagraph type G to ceate new datagraphs of that type.

### Registry

Support applying functions to each graph in a registry.
Useful to convert all graphs in a given registry to a different
type to allow easy access to properties of graphs, nodes, edges.

### DataGraph

Add a method to create a new datagraph of `type(self)`
using the underlying data of another datagraph. Allows to realize
code like this

```python
def merge_dgraphs[G: MyDataGraph](b: G, reg: Registry[DataGraph]) -> G:
  a = b.with_data_from(reg["a"])
  for node in _a.nodes.values():
    if node.my_field == "my_value":
      b = b.add_node(node)
  return b
```

### Factories

Simplify implementations by

- using the two new features from above
- removing the separate NodeEdgeFactory implementation
- making `StdIrFactory` take functions with signatures of
  Node/Edge/Graph constructors as argument

Support conversion from arbitrary datagraphs to specific types.
Enabled by the new feature for graphs.

Use factories as sole entry point into ir variants by
adding registry creation and conversion to them.



BREAKING CHANGE:
 - direct calls to graph constructors are now kw only
 - `StdIrFactory` now takes a graph constructor instead of the previous
   function as an argument
