### PR TITLE
feat(hdl_ir): get only transitive closure of a single data graph

### DIFF
--- a/src/elasticai/creator/hdl_ir.py
+++ b/src/elasticai/creator/hdl_ir.py
@@ -266,3 +266,19 @@ type Code = tuple[str, Sequence[str]]
 type Registry = ir.Registry[DataGraph]
 type TypeHandler = Callable[[DataGraph, Registry], Iterable[Code]]
 type NonIterableTypeHandler = Callable[[DataGraph, Registry], Code]
+
+
+def collect_transitive_implementation_closure[G: DataGraph](
+    main: str, reg: ir.Registry[G]
+) -> ir.Registry[G]:
+    closure = {main}
+    check_now = [main]
+    while check_now:
+        design_name = check_now.pop(0)
+        design = reg[design_name]
+        for node in design.nodes.values():
+            if node.implementation in reg and node.implementation not in closure:
+                closure.add(node.implementation)
+                check_now.append(node.implementation)
+    dead_impls = set(reg.keys()) - closure
+    return reg.without(dead_impls)

--- a/tests/unit_tests/hdl_ir_test.py
+++ b/tests/unit_tests/hdl_ir_test.py
@@ -1,0 +1,22 @@
+from elasticai.creator.hdl_ir import (
+    IrFactory,
+    collect_transitive_implementation_closure,
+)
+from elasticai.creator.ir import Registry
+
+factory = IrFactory()
+
+
+def test_can_remove_dead_implementations_from_reg():
+    g = factory.graph()
+    reg = Registry(
+        main=g.add_nodes(
+            factory.node("a", implementation="a_impl"),
+            factory.node("b", implementation="b_impl"),
+        ),
+        a_impl=g,
+        c_impl=g,
+    )
+    result = collect_transitive_implementation_closure("main", reg)
+    assert "a_impl" in result
+    assert "c_impl" not in result


### PR DESCRIPTION
This allows implementations of hdl translation passes to clean
up leftover unused implementations.
