### PR TITLE
feat(rewriting): add rule composition

### DIFF
--- a/src/elasticai/creator/ir/__init__.py
+++ b/src/elasticai/creator/ir/__init__.py
@@ -7,7 +7,14 @@ from .datagraph_impl import (
     EdgeImpl,
     NodeImpl,
 )
-from .datagraph_rewriting import Pattern, PatternRule, PatternRuleSpec, Rule, StdPattern
+from .datagraph_rewriting import (
+    Pattern,
+    PatternRule,
+    PatternRuleSpec,
+    Rule,
+    StdPattern,
+    compose_rules,
+)
 from .deserializer import IrDeserializer, IrDeserializerLegacy
 from .factories import IrFactory, StdIrFactory
 from .graph import Graph, GraphImpl
@@ -43,4 +50,5 @@ __all__ = [
     "PatternRuleSpec",
     "StdPattern",
     "Rule",
+    "compose_rules",
 ]

--- a/src/elasticai/creator/ir/datagraph_rewriting.py
+++ b/src/elasticai/creator/ir/datagraph_rewriting.py
@@ -269,3 +269,12 @@ class _NameGenerator:
     def get_name(self, name: str) -> str:
         new_name = self._registry.get_unique_name(name)
         return new_name
+
+
+def compose_rules[G: DataGraph](*rules: Rule[G, G]) -> Rule[G, G]:
+    def composed(graph: G, reg: Registry[G]) -> tuple[G, Registry[G]]:
+        for rule in rules:
+            graph, reg = rule(graph, reg)
+        return graph, reg
+
+    return composed


### PR DESCRIPTION
Often, we have to apply several similar or dependent rules in a row.
One main reason is having to apply the same replacement for different
patterns, e.g., to remove a specific layer only if it occurs at a
certain position while just wanting to remove other layer types
from everywhere.
The `compose_rules` function allows devs to easily group
several rules into one coherent unit.
