### PR TITLE
feat(plugins.lutron_filter): add removal of redundant layers for precomp

### DIFF
--- a/plugins/lutron_filter/pyproject.toml
+++ b/plugins/lutron_filter/pyproject.toml
@@ -6,11 +6,15 @@ dependencies = [
   "elasticai-creator",
   "matplotlib>=3.10.9",
   "networkx>=3.6.1",
+  "torch>=2.11.0",
 ]
 
 [build-system]
 requires = ["uv_build>=0.11.8,<0.12"]
 build-backend = "uv_build"
+
+[tool.ty.environment]
+root = ["./src"]
 
 [tool.uv.build-backend]
 module-name = "elasticai.creator_plugins.lutron_filter"

--- a/plugins/lutron_filter/src/elasticai/creator_plugins/lutron_filter/__init__.py
+++ b/plugins/lutron_filter/src/elasticai/creator_plugins/lutron_filter/__init__.py
@@ -11,6 +11,7 @@ from .rules import (
     binarize_activations,
     make_split_conv_rule,
     precompute_linear,
+    remove_redundant_layers,
     reorder,
 )
 from .rules._ir import DataGraph, Registry, build_sequential_ir
@@ -36,6 +37,7 @@ __all__ = [
     "get_default_torch2ir",
     "make_split_conv_rule",
     "precompute_linear",
+    "remove_redundant_layers",
     "reorder",
     "torch1d_input_tensor_to_grouped_strings",
 ]

--- a/plugins/lutron_filter/src/elasticai/creator_plugins/lutron_filter/rules/__init__.py
+++ b/plugins/lutron_filter/src/elasticai/creator_plugins/lutron_filter/rules/__init__.py
@@ -1,6 +1,7 @@
 from ._binarize_activations import binarize_activations
 from ._precomputation import PrecomputationStrategy, make_precompute_rule
 from ._precomputation_impls import precompute_linear
+from ._remove_redundant_layers import remove_redundant_layers
 from ._reorder import reorder
 from ._shape_inference import (
     AttachFilterParametersRule,
@@ -21,4 +22,5 @@ __all__ = [
     "make_split_conv_rule",
     "precompute_linear",
     "reorder",
+    "remove_redundant_layers",
 ]

--- a/plugins/lutron_filter/src/elasticai/creator_plugins/lutron_filter/rules/_remove_redundant_layers.py
+++ b/plugins/lutron_filter/src/elasticai/creator_plugins/lutron_filter/rules/_remove_redundant_layers.py
@@ -1,0 +1,56 @@
+from elasticai.creator import ir as _ir
+
+from . import _ir as _lf_ir
+from ._ir import pattern_rule, sequential_with_interface
+
+
+def _constraint(
+    pattern_node: _lf_ir.Node,
+    graph_node: _lf_ir.Node,
+    /,
+) -> bool:
+    match pattern_node.name:
+        case "start":
+            return graph_node.type in ("filter", "input")
+        case "end":
+            return True
+        case _:
+            return graph_node.type in ("binarize", "flatten")
+
+
+def _match_only_final_sigmoid(
+    pattern_node: _lf_ir.Node, graph_node: _lf_ir.Node
+) -> bool:
+    match pattern_node.name:
+        case "start":
+            return graph_node.type in ("filter", "input")
+        case "end":
+            return graph_node.type == "output"
+        case _:
+            return graph_node.type == "sigmoid"
+
+
+def _replacement_fn[G: _ir.DataGraph](
+    match: G, registry: _ir.Registry[G]
+) -> tuple[G, _ir.Registry[G]]:
+    edge = ("start", "end")
+    new_seq = [match.nodes[n] for n in edge]
+    new_g = match.clear().add_nodes(*new_seq).add_edge(*edge)
+    return new_g, registry
+
+
+def _make_remover(
+    constraint: _lf_ir.NodeConstraint,
+) -> _lf_ir.Rule[_lf_ir.DataGraph, _lf_ir.DataGraph]:
+
+    remove_redundant_layers = pattern_rule(
+        graph=sequential_with_interface("redundant"),
+        replacement_fn=_replacement_fn,
+        make_node_constraint=lambda _: constraint,
+    )
+    return remove_redundant_layers
+
+
+remove_redundant_layers = _ir.compose_rules(
+    *map(_make_remover, (_constraint, _match_only_final_sigmoid))
+)

--- a/plugins/lutron_filter/tests/unit/remove_redundant_layers_test.py
+++ b/plugins/lutron_filter/tests/unit/remove_redundant_layers_test.py
@@ -1,0 +1,68 @@
+import elasticai.creator_plugins.lutron_filter as lf
+import pytest
+from elasticai.creator_plugins.lutron_filter import remove_redundant_layers
+
+from elasticai.creator.ir import attribute
+
+
+@pytest.fixture
+def ir_repr(request):
+    layer_type = request.param
+    return lf.build_sequential_ir(
+        dict(
+            main=attribute(),
+            a=attribute(type="filter"),
+            b=attribute(type="filter"),
+            redundant=attribute(type=layer_type),
+        ),
+        sequence=("a", "redundant", "b"),
+    )
+
+
+@pytest.mark.parametrize("ir_repr", ("sigmoid",), indirect=True)
+def test_dont_remove_sigmoid_in_middle(ir_repr):
+    expected, _ = ir_repr
+    result, _ = lf.remove_redundant_layers(*ir_repr)
+    assert get_impl_edges(expected) == get_impl_edges(result)
+
+
+@pytest.mark.parametrize("ir_repr", ("binarize", "flatten"), indirect=True)
+def test_remove_non_sigmoid(ir_repr: tuple[lf.DataGraph, lf.Registry[lf.DataGraph]]):
+    result, _ = lf.remove_redundant_layers(*ir_repr)
+    expected = (
+        ir_repr[0]
+        .remove_edge("0", "1")
+        .remove_edge("1", "2")
+        .remove_node("1")
+        .add_edge("0", "2")
+    )
+
+    assert get_impl_edges(expected) == get_impl_edges(result)
+
+
+def test_remove_final_sigmoid():
+
+    g, reg = lf.build_sequential_ir(
+        dict(
+            main=attribute(),
+            a=attribute(type="filter"),
+            b=attribute(type="filter"),
+            redundant=attribute(type="sigmoid"),
+        ),
+        sequence=("a", "b", "redundant"),
+    )
+    expected = g.remove_edge("2", "output").remove_node("2").add_edge("1", "output")
+    g, _ = remove_redundant_layers(g, reg)
+    assert get_impl_edges(expected) == get_impl_edges(g)
+
+
+def get_edge_nodes(g):
+    for edge in g.edges.values():
+        yield g.nodes[edge.src], g.nodes[edge.dst]
+
+
+def get_impl_edges(g: lf.DataGraph) -> set[tuple[str, str]]:
+    edges: set[tuple[str, str]] = set()
+    for src, dst in get_edge_nodes(g):
+        edges.add((src.implementation, dst.implementation))
+    return edges

--- a/uv.lock
+++ b/uv.lock
@@ -744,6 +744,7 @@ dependencies = [
     { name = "elasticai-creator" },
     { name = "matplotlib" },
     { name = "networkx" },
+    { name = "torch" },
 ]
 
 [package.metadata]
@@ -751,6 +752,7 @@ requires-dist = [
     { name = "elasticai-creator", editable = "." },
     { name = "matplotlib", specifier = ">=3.10.9" },
     { name = "networkx", specifier = ">=3.6.1" },
+    { name = "torch", specifier = ">=2.11.0", index = "https://pypi.org/simple" },
 ]
 
 [[package]]


### PR DESCRIPTION
Prior code generation we want to get rid of some redundant layers
because they are merged into the precomputed components, e.g.,
binarizations
