### PR TITLE
fix(cocotb-pytest): Fixed error in lut table generation

### DIFF
--- a/src/elasticai/creator/nn/fixed_point/precomputed/precomputed_module.py
+++ b/src/elasticai/creator/nn/fixed_point/precomputed/precomputed_module.py
@@ -59,15 +59,8 @@ class PrecomputedModule(DesignCreatorModule):
             ),
             persistent=False,
         )
-        lut_diff = (
-            torch.abs(torch.diff(self._lut_input))
-            / self._params.minimum_step_as_rational
-            / 2
-        )
-        self._xoffset = (
-            float((lut_diff.max() + lut_diff.min()) / 2)
-            * self._params.minimum_step_as_rational
-        )
+        lut_diff = torch.abs(torch.diff(self._lut_input))
+        self._xoffset = float((lut_diff.max() + lut_diff.min()) / 4)
 
     def get_lut_integer(self) -> tuple[list[int], list[int]]:
         return (
@@ -78,10 +71,11 @@ class PrecomputedModule(DesignCreatorModule):
     def _stepped_inputs(self, x: torch.Tensor) -> torch.Tensor:
         return cast(torch.Tensor, IdentityStepFunction.apply(x, self._lut_input))
 
-    def _forward_nograd(self, x: int) -> int:
-        fxp_input = self._config.as_rational(x)
-        if not isinstance(fxp_input, float):
-            raise ValueError()
+    def _forward_nograd(self, x: int | float) -> int:
+        if isinstance(x, float):
+            fxp_input = x
+        else:
+            fxp_input = self._config.as_rational(x)
 
         with torch.no_grad():
             output = self.forward(torch.tensor(fxp_input).clone().detach())

--- a/tests/unit_tests/nn/fixed_point/prelu/layer_func_test.py
+++ b/tests/unit_tests/nn/fixed_point/prelu/layer_func_test.py
@@ -44,3 +44,39 @@ def test_prelu_compared_torch(total_bits: int, frac_bits: int, num_steps: int) -
         out1.max() - out1.min()
     )
     assert metric_mean < 0.7 * fxp.minimum_step_as_rational
+
+
+@pytest.mark.parametrize(
+    "total_bits, frac_bits, num_steps, q_input, q_output",
+    [
+        (
+            4,
+            3,
+            12,
+            [-8, -7, -5, -4, -3, -1, 0, 2, 3, 4, 6, 7],
+            [-2, -2, -1, -1, -1, 0, 0, 1, 2, 3, 5, 6],
+        ),
+        (
+            4,
+            3,
+            16,
+            [-8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7],
+            [-2, -2, -2, -1, -1, -1, -1, 0, 0, 0, 2, 2, 4, 4, 6, 6],
+        ),
+    ],
+)
+def test_transfer_function_precomputed_prelu(
+    total_bits: int,
+    frac_bits: int,
+    num_steps: int,
+    q_input: list[int],
+    q_output: list[int],
+) -> None:
+    act = nn_creator.PReLU(
+        total_bits=total_bits, frac_bits=frac_bits, num_steps=num_steps
+    )
+    qin_result, qout_result = act.get_lut_integer()
+    assert len(qin_result) == num_steps
+    assert len(qout_result) == num_steps
+    assert q_input == qin_result
+    assert q_output == qout_result

--- a/tests/unit_tests/nn/fixed_point/sigmoid/layer_func_test.py
+++ b/tests/unit_tests/nn/fixed_point/sigmoid/layer_func_test.py
@@ -42,3 +42,105 @@ def test_sigmoid_compared_torch(
         out1.max() - out1.min()
     )
     assert metric_mean < 0.6 * fxp.minimum_step_as_rational
+
+
+@pytest.mark.parametrize(
+    "total_bits, frac_bits, num_steps, q_input, q_output",
+    [
+        (
+            5,
+            3,
+            12,
+            [-16, -13, -10, -8, -5, -2, 1, 4, 7, 9, 12, 15],
+            [1, 1, 2, 2, 3, 3, 4, 5, 5, 6, 6, 7],
+        ),
+        (
+            5,
+            3,
+            32,
+            [
+                -16,
+                -15,
+                -14,
+                -13,
+                -12,
+                -11,
+                -10,
+                -9,
+                -8,
+                -7,
+                -6,
+                -5,
+                -4,
+                -3,
+                -2,
+                -1,
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+            ],
+            [
+                1,
+                1,
+                1,
+                1,
+                1,
+                2,
+                2,
+                2,
+                2,
+                2,
+                2,
+                3,
+                3,
+                3,
+                3,
+                4,
+                4,
+                4,
+                4,
+                5,
+                5,
+                5,
+                5,
+                6,
+                6,
+                6,
+                6,
+                6,
+                6,
+                7,
+                7,
+                7,
+            ],
+        ),
+    ],
+)
+def test_transfer_function_precomputed_sigmoid(
+    total_bits: int,
+    frac_bits: int,
+    num_steps: int,
+    q_input: list[int],
+    q_output: list[int],
+) -> None:
+    act = nn_creator.Sigmoid(
+        total_bits=total_bits, frac_bits=frac_bits, num_steps=num_steps
+    )
+    qin_result, qout_result = act.get_lut_integer()
+    assert len(qin_result) == num_steps
+    assert len(qout_result) == num_steps
+    assert q_input == qin_result
+    assert q_output == qout_result

--- a/tests/unit_tests/nn/fixed_point/silu/layer_func_test.py
+++ b/tests/unit_tests/nn/fixed_point/silu/layer_func_test.py
@@ -57,3 +57,39 @@ def test_silu_compared_torch(total_bits: int, frac_bits: int, num_steps: int) ->
         out1.max() - out1.min()
     )
     assert metric_mean < 0.6 * fxp.minimum_step_as_rational
+
+
+@pytest.mark.parametrize(
+    "total_bits, frac_bits, num_steps, q_input, q_output",
+    [
+        (
+            4,
+            2,
+            16,
+            [-8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7],
+            [-1, -1, -1, -1, -1, -1, -1, -1, 0, 0, 1, 2, 2, 3, 4, 5],
+        ),
+        (
+            4,
+            3,
+            16,
+            [-8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7],
+            [-2, -2, -2, -2, -2, -1, -1, -1, 0, 0, 1, 1, 2, 3, 4, 5],
+        ),
+    ],
+)
+def test_transfer_function_precomputed_silu(
+    total_bits: int,
+    frac_bits: int,
+    num_steps: int,
+    q_input: list[int],
+    q_output: list[int],
+) -> None:
+    act = nn_creator.SiLU(
+        total_bits=total_bits, frac_bits=frac_bits, num_steps=num_steps
+    )
+    qin_result, qout_result = act.get_lut_integer()
+    assert len(qin_result) == num_steps
+    assert len(qout_result) == num_steps
+    assert q_input == qin_result
+    assert q_output == qout_result

--- a/tests/unit_tests/nn/fixed_point/silu_adaptible/layer_func_test.py
+++ b/tests/unit_tests/nn/fixed_point/silu_adaptible/layer_func_test.py
@@ -33,3 +33,33 @@ def test_silu_compared_torch(total_bits: int, frac_bits: int, num_steps: int) ->
         out0.max() - out0.min()
     )
     assert metric_mean < 0.6 * fxp.minimum_step_as_rational
+
+
+@pytest.mark.parametrize(
+    "total_bits, frac_bits, num_steps, q_input, q_output",
+    [
+        (3, 2, 8, [-4, -3, -2, -1, 0, 1, 2, 3], [-1, -1, -1, -1, 0, 0, 1, 2]),
+        (
+            5,
+            3,
+            16,
+            [-16, -14, -12, -10, -8, -6, -4, -2, 1, 3, 5, 7, 9, 11, 13, 15],
+            [-2, -2, -2, -2, -2, -2, -2, -1, 0, 1, 2, 4, 6, 8, 10, 12],
+        ),
+    ],
+)
+def test_transfer_function_precomputed_adapt_silu(
+    total_bits: int,
+    frac_bits: int,
+    num_steps: int,
+    q_input: list[int],
+    q_output: list[int],
+) -> None:
+    act = nn_creator.AdaptableSiLU(
+        total_bits=total_bits, frac_bits=frac_bits, num_steps=num_steps
+    )
+    qin_result, qout_result = act.get_lut_integer()
+    assert len(qin_result) == num_steps
+    assert len(qout_result) == num_steps
+    assert q_input == qin_result
+    assert q_output == qout_result

--- a/tests/unit_tests/nn/fixed_point/tanh/layer_func_test.py
+++ b/tests/unit_tests/nn/fixed_point/tanh/layer_func_test.py
@@ -45,3 +45,39 @@ def test_tanh_compared_torch(total_bits: int, frac_bits: int, num_steps: int) ->
         out1.max() - out1.min()
     )
     assert metric_mean < 0.6 * fxp.minimum_step_as_rational
+
+
+@pytest.mark.parametrize(
+    "total_bits, frac_bits, num_steps, q_input, q_output",
+    [
+        (
+            4,
+            2,
+            16,
+            [-8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7],
+            [-4, -4, -4, -4, -3, -3, -2, -1, 0, 0, 1, 2, 3, 3, 4, 4],
+        ),
+        (
+            6,
+            3,
+            16,
+            [-32, -28, -24, -19, -15, -11, -7, -3, 2, 6, 10, 14, 18, 23, 27, 31],
+            [-8, -8, -8, -8, -8, -7, -7, -5, 0, 3, 6, 7, 8, 8, 8, 8],
+        ),
+    ],
+)
+def test_transfer_function_precomputed_tanh(
+    total_bits: int,
+    frac_bits: int,
+    num_steps: int,
+    q_input: list[int],
+    q_output: list[int],
+) -> None:
+    act = nn_creator.Tanh(
+        total_bits=total_bits, frac_bits=frac_bits, num_steps=num_steps
+    )
+    qin_result, qout_result = act.get_lut_integer()
+    assert len(qin_result) == num_steps
+    assert len(qout_result) == num_steps
+    assert q_input == qin_result
+    assert q_output == qout_result


### PR DESCRIPTION
There was an error in building the LUT tables of the transfer function. It receives a float input and scale it down again. There was no check if float or int.
