### PR TITLE
fix(cocotb-fixture): delete test artifact folder before simulation test

### DIFF
--- a/src/elasticai/creator/testing/cocotb_prepare.py
+++ b/src/elasticai/creator/testing/cocotb_prepare.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from shutil import rmtree
 
 from elasticai.creator.file_generation import find_project_root
 
@@ -11,6 +12,7 @@ def build_report_folder_and_testdata(dut_name: str, testdata: dict) -> Path:
     :return:                Path to the report folder containing hardware design and testpattern data
     """
     build_dir = find_project_root() / "build_test" / dut_name.lower()
+    rmtree(build_dir, ignore_errors=True)
     build_dir.mkdir(exist_ok=True, parents=True)
 
     file_name = "testdata.json"


### PR DESCRIPTION
I had several times the effect, that the design files is not refreshed
after changes. Or just changing the file names leads to test errors.
To avoid this the test folder will be removed before the tests starts.
No performance penalty because we are currently rebuilding object
files everytime anyways.
