### PR TITLE
fix(torch2ir): return the datagraph type defined by ir2torch

### DIFF
--- a/src/elasticai/creator/experimental/ir/shape_inference/shape_inference.py
+++ b/src/elasticai/creator/experimental/ir/shape_inference/shape_inference.py
@@ -1,10 +1,9 @@
-from collections.abc import Callable, Iterator
-from typing import Any, Iterable, Protocol, cast
+from collections.abc import Callable, Iterable, Iterator
+from typing import Any, Protocol, cast
 
 import elasticai.creator.function_dispatch as FD
 from elasticai.creator import ir
 from elasticai.creator.graph import bfs_iter_down
-from elasticai.creator.ir2torch.ir2torch import _DataGraph
 
 type DataGraph = ir.DataGraph[ir.Node, ir.Edge]
 type Registry = ir.Registry[DataGraph]
@@ -205,8 +204,8 @@ class _ShapedEdgeImpl(ir.EdgeImpl):
         return _guard_shape(self.attributes["shape"])
 
 
-class IrFactory(ir.StdIrFactory):
+class IrFactory(ir.StdIrFactory[Node, ShapedEdge, ShapedDatagraph]):
     def __init__(self):
         super().__init__(
-            node_fn=_NodeImpl, edge_fn=_ShapedEdgeImpl, graph_fn=_DataGraph
+            node_fn=_NodeImpl, edge_fn=_ShapedEdgeImpl, graph_fn=ir.DataGraphImpl
         )

--- a/src/elasticai/creator/experimental/ir/shape_inference/tests/ir2shapes_test.py
+++ b/src/elasticai/creator/experimental/ir/shape_inference/tests/ir2shapes_test.py
@@ -1,11 +1,15 @@
+from typing import final, override
+
 import pytest
+from torch import Tensor
 from torch.nn import BatchNorm2d, Conv2d, Flatten, Linear, Module, ReLU, Sequential
 
 from elasticai.creator import ir, torch2ir
 from elasticai.creator.experimental.ir.shape_inference import (
     get_default_shape_inference,
 )
-from elasticai.creator.torch2ir.torch2ir import DataGraph, Registry
+from elasticai.creator.ir import Registry
+from elasticai.creator.torch2ir.torch2ir import DataGraph
 
 
 def model():
@@ -16,6 +20,7 @@ def model():
 
 
 def model_skip_connection():
+    @final
     class SkipConnection(Module):
         def __init__(self):
             super().__init__()
@@ -25,9 +30,10 @@ def model_skip_connection():
             self.batchnorm2d = BatchNorm2d(2)
             self.flatten = Flatten()
 
-        def forward(self, x):
+        @override
+        def forward(self, x: Tensor) -> Tensor:
             identity = x
-            y = self.conv2d(x)
+            y: Tensor = self.conv2d(x)
             y = self.relu(y)
             y = self.batchnorm2d(y)
             y += identity

--- a/src/elasticai/creator/ir/registry.py
+++ b/src/elasticai/creator/ir/registry.py
@@ -1,22 +1,22 @@
 from collections.abc import Callable, Collection, Iterable, Iterator, Mapping
-from typing import Any, Self, cast, overload
+from typing import Self, overload, override
 
-from .datagraph import DataGraph
+from .datagraph import DataGraph, Edge, Node
 
-_registry_types = []
-
-
-def is_registry(object) -> bool:
-    return object in _registry_types
+_registry_types: list[type] = []
 
 
-def mark_as_registry[T](object: T) -> T:
+def is_registry(obj: type) -> bool:
+    return obj in _registry_types
+
+
+def mark_as_registry[T](object: type[T]) -> type[T]:
     _registry_types.append(object)
     return object
 
 
 @mark_as_registry
-class Registry[G: DataGraph](Mapping[str, G]):
+class Registry[G: DataGraph[Node, Edge]](Mapping[str, G]):
     @overload
     def __init__(self, items: Iterable[tuple[str, G]], /) -> None: ...
     @overload
@@ -28,36 +28,38 @@ class Registry[G: DataGraph](Mapping[str, G]):
         self,
         items: Iterable[tuple[str, G]] | Mapping[str, G] | None = None,
         /,
-        **kwargs,
+        **kwargs: G,
     ) -> None:
         if items is None:
-            self._data: dict[str, G] = dict(**kwargs)
+            self._data: dict[str, G] = kwargs
         else:
             if not len(kwargs) == 0:
                 raise TypeError(f"unsupported arguments for {type(self)}")
             self._data = dict(items)
 
+    @override
     def __getitem__(self, name: str) -> G:
-        return cast(G, self._data[name])
+        return self._data[name]
 
+    @override
     def __len__(self) -> int:
         return len(self._data)
 
+    @override
     def __contains__(self, key: object) -> bool:
         return key in self._data
 
+    @override
     def __iter__(self) -> Iterator[str]:
         yield from self._data
 
-    def __or__(self, other: object) -> Self:
-        if not isinstance(other, Mapping):
-            raise TypeError("unsupported operand")
-        return type(self)(**(self._data | dict(other.items())))  # type: ignore
+    def __or__(self, other: Mapping[str, G]) -> Self:
+        return type(self)((self._data | dict(other.items())))
 
     def add(self, name: str, graph: G) -> Self:
         return type(self)(**(self._data) | {name: graph})
 
-    def apply[G2: DataGraph](self, fn: Callable[[G], G2]) -> "Registry[G2]":
+    def apply[G2: DataGraph[Node, Edge]](self, fn: Callable[[G], G2]) -> "Registry[G2]":
         new_dict = ((k, fn(g)) for k, g in self._data.items())
         return Registry(new_dict)
 
@@ -65,12 +67,14 @@ class Registry[G: DataGraph](Mapping[str, G]):
         new_dict = ((k, g) for k, g in self._data.items() if k not in keys)
         return type(self)(new_dict)
 
+    @override
     def __repr__(self) -> str:
         return f"Registry(**{repr(self._data)})"
 
-    def __eq__(self, other: Any) -> bool:
+    @override
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Registry):
-            if set(self.keys()) != other.keys():
+            if self.keys() != other.keys():
                 return False
             for k in self.keys():
                 if self[k] != other[k]:

--- a/src/elasticai/creator/ir2torch/__init__.py
+++ b/src/elasticai/creator/ir2torch/__init__.py
@@ -1,11 +1,13 @@
 from .default_handlers import dgraph_handlers as default_handlers
 from .ir2torch import (
+    DataGraph,
     Ir2Torch,
     IrFactory,
     get_default_converter,
 )
 
 __all__ = [
+    "DataGraph",
     "Ir2Torch",
     "get_default_converter",
     "default_handlers",

--- a/src/elasticai/creator/torch2ir/torch2ir.py
+++ b/src/elasticai/creator/torch2ir/torch2ir.py
@@ -7,6 +7,8 @@ from torch.nn import Module
 
 import elasticai.creator.function_dispatch as FD
 import elasticai.creator.ir as ir
+from elasticai.creator.ir2torch import DataGraph as DataGraph
+from elasticai.creator.ir2torch import IrFactory
 
 from .default_handlers import handlers as default_handlers
 
@@ -23,16 +25,14 @@ class LoweringError(Exception):
         super().__init__(message)
 
 
-type DataGraph = ir.DataGraph[ir.Node, ir.Edge]
-type Registry = ir.Registry[DataGraph]
 type TypeHandler = Callable[[Module], dict]
 
 
 class Torch2Ir:
     def __init__(self, tracer=_DefaultTracer()) -> None:
         self._tracer = tracer
-        self._ir_factory = ir.DefaultIrFactory()
-        self._registry: Registry = ir.Registry()
+        self._ir_factory = IrFactory()
+        self._registry: ir.Registry[DataGraph] = ir.Registry()
         self._root = self._ir_factory.graph(ir.attribute(type="module"))
 
     @FD.dispatch_method()
@@ -74,10 +74,9 @@ class Torch2Ir:
         for successor in self._get_successors(node):
             self._root = self._root.add_edge(node.name, successor.name)
 
-    def convert(self, model: Module) -> tuple[DataGraph, Registry]:
+    def convert(self, model: Module) -> tuple[DataGraph, ir.Registry[DataGraph]]:
         self.model = model
         torch_graph = self._tracer.trace(model)
-        registry: Registry = ir.Registry()
         for node in torch_graph.nodes:
             self._handle_fx_node(node)
         registry = self._registry
@@ -132,7 +131,7 @@ class Torch2Ir:
         module = self.model.get_submodule(cast(str, node.target))
         return self._extractors(module)
 
-    def __call__(self, model: Module) -> tuple[DataGraph, Registry]:
+    def __call__(self, model: Module) -> tuple[DataGraph, ir.Registry[DataGraph]]:
         return self.convert(model)
 
 


### PR DESCRIPTION
This makes it easier and more consistent to convert
the result of torch2ir back to torch using ir2torch.
