### PR TITLE
chore(devenv): fix devenv setup

### DIFF
--- a/devenv.yaml
+++ b/devenv.yaml
@@ -4,5 +4,5 @@ inputs:
   nixpkgs-unstable:
     url: github:nixos/nixpkgs/nixpkgs-unstable
 imports:
-  - ./devenv_modules/hdl/
-  - ./devenv_modules/torch_backend/
+  - ./devenv_modules/hdl
+  - ./devenv_modules/torch_backend

--- a/secretspec.toml
+++ b/secretspec.toml
@@ -2,7 +2,5 @@
 name = "elasticai-new-creator"
 revision = "1.0"
 
-[profiles.default]
-
 [profiles.development]
 SYNTH_HOST = { description = "SYNTH_HOST secret", required = true }


### PR DESCRIPTION
trailing backslashes in devenv.yaml lead
to the modules getting included twice
which again lead to multiple declaration errors
